### PR TITLE
Fix the AudioParam method names

### DIFF
--- a/generator/templates/audio_param.tmpl.rs
+++ b/generator/templates/audio_param.tmpl.rs
@@ -43,8 +43,8 @@ impl NapiAudioParam {
                 .with_method(exponential_ramp_to_value_at_time),
             Property::new("setValueCurveAtTime")?.with_method(set_value_curve_at_time),
             Property::new("setTargetAtTime")?.with_method(set_target_at_time),
-            Property::new("CancelScheduledValues")?.with_method(cancel_scheduled_values),
-            Property::new("CancelAndOldAtTime")?.with_method(cancel_and_hold_at_time),
+            Property::new("cancelScheduledValues")?.with_method(cancel_scheduled_values),
+            Property::new("cancelAndOldAtTime")?.with_method(cancel_and_hold_at_time),
         ])?;
 
         Ok(obj)

--- a/generator/templates/audio_param.tmpl.rs
+++ b/generator/templates/audio_param.tmpl.rs
@@ -44,7 +44,7 @@ impl NapiAudioParam {
             Property::new("setValueCurveAtTime")?.with_method(set_value_curve_at_time),
             Property::new("setTargetAtTime")?.with_method(set_target_at_time),
             Property::new("cancelScheduledValues")?.with_method(cancel_scheduled_values),
-            Property::new("cancelAndOldAtTime")?.with_method(cancel_and_hold_at_time),
+            Property::new("cancelAndHoldAtTime")?.with_method(cancel_and_hold_at_time),
         ])?;
 
         Ok(obj)

--- a/src/audio_param.rs
+++ b/src/audio_param.rs
@@ -94,7 +94,7 @@ impl NapiAudioParam {
             Property::new("setValueCurveAtTime")?.with_method(set_value_curve_at_time),
             Property::new("setTargetAtTime")?.with_method(set_target_at_time),
             Property::new("cancelScheduledValues")?.with_method(cancel_scheduled_values),
-            Property::new("cancelAndOldAtTime")?.with_method(cancel_and_hold_at_time),
+            Property::new("cancelAndHoldAtTime")?.with_method(cancel_and_hold_at_time),
         ])?;
 
         Ok(obj)

--- a/src/audio_param.rs
+++ b/src/audio_param.rs
@@ -93,8 +93,8 @@ impl NapiAudioParam {
                 .with_method(exponential_ramp_to_value_at_time),
             Property::new("setValueCurveAtTime")?.with_method(set_value_curve_at_time),
             Property::new("setTargetAtTime")?.with_method(set_target_at_time),
-            Property::new("CancelScheduledValues")?.with_method(cancel_scheduled_values),
-            Property::new("CancelAndOldAtTime")?.with_method(cancel_and_hold_at_time),
+            Property::new("cancelScheduledValues")?.with_method(cancel_scheduled_values),
+            Property::new("cancelAndOldAtTime")?.with_method(cancel_and_hold_at_time),
         ])?;
 
         Ok(obj)


### PR DESCRIPTION
`cancelScheduledValues` and `cancelAndHoldAtTime` should start with a lowercase letter https://developer.mozilla.org/en-US/docs/Web/API/AudioParam