### PR TITLE
Use array buffer to be closer to WebAudio API

### DIFF
--- a/generator/templates/audio_context.tmpl.rs
+++ b/generator/templates/audio_context.tmpl.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::io::Cursor;
 
 use napi::*;
 use napi_derive::js_function;
@@ -168,13 +168,9 @@ fn decode_audio_data(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioContext>(&js_this)?;
     let context = napi_obj.unwrap();
 
-    let js_obj = ctx.get::<JsObject>(0)?;
-    let js_path = js_obj.get_named_property::<JsString>("path")?;
-    let uf8_path = js_path.into_utf8()?.into_owned()?;
-    let str_path = &uf8_path[..];
-
-    let file = File::open(str_path).unwrap();
-    let audio_buffer = context.decode_audio_data_sync(file);
+    let js_buffer = ctx.get::<JsArrayBuffer>(0)?.into_value()?;
+    let cursor = Cursor::new(js_buffer.to_vec());
+    let audio_buffer = context.decode_audio_data_sync(cursor);
 
     match audio_buffer {
         Ok(audio_buffer) => {

--- a/monkey-patch.js
+++ b/monkey-patch.js
@@ -90,10 +90,6 @@ function patchAudioContext(nativeBinding) {
     }
 
     decodeAudioData(audioData) {
-      if (!isPlainObject(audioData) || !('path' in audioData)) {
-        throw new Error(`Invalid argument, please consider using the load helper`);
-      }
-
       try {
         const audioBuffer = super.decodeAudioData(audioData);
         return Promise.resolve(audioBuffer);
@@ -144,10 +140,6 @@ function patchOfflineAudioContext(nativeBinding) {
     }
 
     decodeAudioData(audioData) {
-      if (!isPlainObject(audioData) || !('path' in audioData)) {
-        throw new Error(`Invalid argument, please consider using the load helper`);
-      }
-
       try {
         const audioBuffer = super.decodeAudioData(audioData);
         return Promise.resolve(audioBuffer);

--- a/monkey-patch.js
+++ b/monkey-patch.js
@@ -90,6 +90,9 @@ function patchAudioContext(nativeBinding) {
     }
 
     decodeAudioData(audioData) {
+      if (!audioData instanceof ArrayBuffer) {
+        throw new Error('Invalid argument, please provide an ArrayBuffer');
+      }
       try {
         const audioBuffer = super.decodeAudioData(audioData);
         return Promise.resolve(audioBuffer);
@@ -140,6 +143,9 @@ function patchOfflineAudioContext(nativeBinding) {
     }
 
     decodeAudioData(audioData) {
+      if (!audioData instanceof ArrayBuffer) {
+        throw new Error('Invalid argument, please provide an ArrayBuffer');
+      }
       try {
         const audioBuffer = super.decodeAudioData(audioData);
         return Promise.resolve(audioBuffer);
@@ -151,16 +157,6 @@ function patchOfflineAudioContext(nativeBinding) {
 
   return OfflineAudioContext;
 }
-
-// dumb method provided to mock an xhr call and mimick browser's API
-// see also `AudioContext.decodeAudioData`
-function load(path) {
-  if (!fs.existsSync(path)) {
-    throw new Error(`File not found: "${path}"`);
-  }
-
-  return { path };
-};
 
 module.exports = function monkeyPatch(nativeBinding) {
   nativeBinding.AudioContext = patchAudioContext(nativeBinding);
@@ -183,9 +179,6 @@ module.exports = function monkeyPatch(nativeBinding) {
     const stream = getUserMediaSync(options);
     return Promise.resolve(stream);
   }
-
-  // utils
-  nativeBinding.load = load;
 
   return nativeBinding;
 }

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -5,7 +5,7 @@
 // ---------------------------------------------------------- //
 // ---------------------------------------------------------- //
 
-use std::fs::File;
+use std::io::Cursor;
 
 use napi::*;
 use napi_derive::js_function;
@@ -177,13 +177,9 @@ fn decode_audio_data(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioContext>(&js_this)?;
     let context = napi_obj.unwrap();
 
-    let js_obj = ctx.get::<JsObject>(0)?;
-    let js_path = js_obj.get_named_property::<JsString>("path")?;
-    let uf8_path = js_path.into_utf8()?.into_owned()?;
-    let str_path = &uf8_path[..];
-
-    let file = File::open(str_path).unwrap();
-    let audio_buffer = context.decode_audio_data_sync(file);
+    let js_buffer = ctx.get::<JsArrayBuffer>(0)?.into_value()?;
+    let cursor = Cursor::new(js_buffer.to_vec());
+    let audio_buffer = context.decode_audio_data_sync(cursor);
 
     match audio_buffer {
         Ok(audio_buffer) => {


### PR DESCRIPTION
Ended up needing this change to work with already existing WebAudio projects. Let me know if it makes more sense to maintain backward compatibility.

https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/decodeAudioData