### PR TITLE
Feat - error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ src-manual
 dummy.mjs
 
 issues
+
+all-check.sh

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -7,6 +7,10 @@ import * as nodeWebAudioAPI from '../index.mjs';
 
 // mocks
 import createXMLHttpRequest from './wpt-mock/XMLHttpRequest.js';
+import {
+  NotSupportedError,
+  InvalidStateError,
+} from '../js/lib/errors.js';
 
 program
   .option('--list', 'List the name of the test files')
@@ -41,7 +45,12 @@ const setup = window => {
   window.Float32Array = Float32Array;
 
   // e.g. 'resources/audiobuffersource-multi-channels-expected.wav'
-  window.XMLHttpRequest = createXMLHttpRequest(testsPath)
+  window.XMLHttpRequest = createXMLHttpRequest(testsPath);
+  // errors
+  window.TypeError = TypeError;
+  window.RangeError = RangeError;
+  window.NotSupportedError = NotSupportedError;
+  window.InvalidStateError = InvalidStateError;
 }
 
 const filterRe = new RegExp(`${options.filter}`);

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -41,6 +41,8 @@ const rootURL = 'webaudio';
 const setup = window => {
   Object.assign(window, nodeWebAudioAPI);
 
+  window.navigator.mediaDevices = nodeWebAudioAPI.mediaDevices;
+
   // seems required (weirdly...), cf. `the-audiobuffer-interface/audiobuffer.html`
   window.Float32Array = Float32Array;
 

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -7,10 +7,10 @@ import * as nodeWebAudioAPI from '../index.mjs';
 
 // mocks
 import createXMLHttpRequest from './wpt-mock/XMLHttpRequest.js';
-import {
-  NotSupportedError,
-  InvalidStateError,
-} from '../js/lib/errors.js';
+// import {
+//   NotSupportedError,
+//   InvalidStateError,
+// } from '../js/lib/errors.js';
 
 program
   .option('--list', 'List the name of the test files')
@@ -41,19 +41,30 @@ const rootURL = 'webaudio';
 const setup = window => {
   Object.assign(window, nodeWebAudioAPI);
 
-  window.navigator.mediaDevices = nodeWebAudioAPI.mediaDevices;
+  // window.navigator.mediaDevices = nodeWebAudioAPI.mediaDevices;
 
   // seems required (weirdly...), cf. `the-audiobuffer-interface/audiobuffer.html`
   window.Float32Array = Float32Array;
 
   // e.g. 'resources/audiobuffersource-multi-channels-expected.wav'
   window.XMLHttpRequest = createXMLHttpRequest(testsPath);
+  // window.requestAnimationFrame = func => setInterval(func, 16);
   // errors
   window.TypeError = TypeError;
   window.RangeError = RangeError;
-  window.NotSupportedError = NotSupportedError;
-  window.InvalidStateError = InvalidStateError;
+  window.Error = Error;
+  // window.NotSupportedError = NotSupportedError;
+  // window.InvalidStateError = InvalidStateError;
 }
+
+// try catch unhandled error to prevent wpt process from crashing
+process
+  .on('unhandledRejection', err => {
+    console.error(err.message);
+  })
+  .on('uncaughtException', err => {
+    console.error(err.message);
+  });
 
 const filterRe = new RegExp(`${options.filter}`);
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 napi = {version="2.14", features=["napi9", "tokio_rt"]}
 napi-derive = "2.14"
 uuid = {version="1.6.1", features = ["v4","fast-rng"]}
-# web-audio-api = "0.40"
-web-audio-api = { path = "../web-audio-api-rs" }
+web-audio-api = "0.41"
+# web-audio-api = { path = "../web-audio-api-rs" }
 
 [target.'cfg(all(any(windows, unix), target_arch = "x86_64", not(target_env = "musl")))'.dependencies]
 mimalloc = {version = "0.1"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 napi = {version="2.14", features=["napi9", "tokio_rt"]}
 napi-derive = "2.14"
 uuid = {version="1.6.1", features = ["v4","fast-rng"]}
-web-audio-api = "0.40"
-# web-audio-api = { path = "../web-audio-api-rs" }
+# web-audio-api = "0.40"
+web-audio-api = { path = "../web-audio-api-rs" }
 
 [target.'cfg(all(any(windows, unix), target_arch = "x86_64", not(target_env = "musl")))'.dependencies]
 mimalloc = {version = "0.1"}

--- a/examples/sink-id.mjs
+++ b/examples/sink-id.mjs
@@ -7,7 +7,7 @@ const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 
 const audioContext = new AudioContext({ latencyHint });
 
 audioContext.addEventListener('sinkchange', (e) => {
-  console.log('sinkchange listener:', e);
+  // console.log('sinkchange listener:', e);
 });
 
 const file = fs.readFileSync(path.join('examples', 'samples', 'sample.wav')).buffer;
@@ -35,6 +35,9 @@ const prompt = readline.createInterface({
   prompt.question(`+ select output deviceId:
 > `, deviceId => {
     audioContext.setSinkId(deviceId);
+
+    console.log('+ switched to sinkId:', audioContext.sinkId);
+
     selectSinkId();
   });
 }());

--- a/generator/index.mjs
+++ b/generator/index.mjs
@@ -271,14 +271,26 @@ let jsOutput = path.join(process.cwd(), 'js');
 // create the mjs export file
 {
   console.log('> generating file: index.mjs (esm re-export)');
-  const esmIndexCodeTempl = fs.readFileSync(path.join(jsTemplates, `index.tmpl.mjs`), 'utf8');
-  const esmIndexTmpl = compile(esmIndexCodeTempl);
-  const esmIndexCode = esmIndexTmpl({
+  const codeTempl = fs.readFileSync(path.join(jsTemplates, `index.tmpl.mjs`), 'utf8');
+  const tmpl = compile(codeTempl);
+  const code = tmpl({
     nodes: audioNodes,
     ...utils,
   });
 
-  fs.writeFileSync(path.join(process.cwd(), 'index.mjs'), generatedPrefix(esmIndexCode));
+  fs.writeFileSync(path.join(process.cwd(), 'index.mjs'), generatedPrefix(code));
+}
+
+{
+  console.log('> generating file: monkey-patch.js');
+  const codeTmpl = fs.readFileSync(path.join(jsTemplates, `monkey-patch.tmpl.js`), 'utf8');
+  const tmpl = compile(codeTmpl);
+  const code = tmpl({
+    nodes: audioNodes,
+    ...utils,
+  });
+
+  fs.writeFileSync(path.join(jsOutput, 'monkey-patch.js'), generatedPrefix(code));
 }
 
 {
@@ -303,6 +315,23 @@ let jsOutput = path.join(process.cwd(), 'js');
   console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
 
   const codeTmpl = fs.readFileSync(path.join(jsTemplates, `AudioNode.mixin.tmpl.js`), 'utf8');
+  const tmpl = compile(codeTmpl);
+
+  const code = tmpl({
+    node: nodeIdl,
+    tree,
+    ...utils
+  });
+
+  fs.writeFileSync(pathname, generatedPrefix(code));
+});
+
+audioNodes.forEach((nodeIdl, index) => {
+  // const nodeIdl = findInTree(name);
+  const pathname = path.join(jsOutput, `${utils.name(nodeIdl)}.js`);
+  console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
+
+  const codeTmpl = fs.readFileSync(path.join(jsTemplates, `AudioNodes.tmpl.js`), 'utf8');
   const tmpl = compile(codeTmpl);
 
   const code = tmpl({

--- a/generator/index.mjs
+++ b/generator/index.mjs
@@ -97,11 +97,15 @@ const utils = {
     return attrs;
   },
 
-  methods(idl) {
+  methods(idl, filterStartStop = true) {
     let methods = idl.members
-      .filter(member => member.constructor.name === 'Operation')
-      .filter(member => member.name !== 'start')
-      .filter(member => member.name !== 'stop')
+      .filter(member => member.constructor.name === 'Operation');
+
+    if (filterStartStop) {
+      methods = methods
+        .filter(member => member.name !== 'start')
+        .filter(member => member.name !== 'stop')
+    }
 
     return methods;
   },
@@ -191,51 +195,54 @@ function findInTree(name) {
   return tree.find(l => l.name === name);
 }
 
+console.log('-------------------------------------------------------------');
 console.log('## generating rs files');
-console.log('');
+console.log('-------------------------------------------------------------');
 
 let rsTemplates = path.join(__dirname, 'rs');
 let rsOutput = path.join(process.cwd(), 'src');
 
-// parse AudioNodes
-const nodesCodeTmpl = fs.readFileSync(path.join(rsTemplates, `audio_nodes.tmpl.rs`), 'utf8');
-const nodesTmpl = compile(nodesCodeTmpl);
+{ // parse AudioNodes
+  const nodesCodeTmpl = fs.readFileSync(path.join(rsTemplates, `audio_nodes.tmpl.rs`), 'utf8');
+  const nodesTmpl = compile(nodesCodeTmpl);
 
-// process audio nodes
-supportedNodes.sort().forEach((name, index) => {
-  const nodeIdl = findInTree(name);
-  const pathname = path.join(rsOutput, `${utils.slug(nodeIdl)}.rs`);
-  console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
+  // process audio nodes
+  supportedNodes.sort().forEach((name, index) => {
+    const nodeIdl = findInTree(name);
+    const pathname = path.join(rsOutput, `${utils.slug(nodeIdl)}.rs`);
+    console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
 
-  const code = nodesTmpl({
-    node: nodeIdl,
-    tree,
-    ...utils
+    const code = nodesTmpl({
+      node: nodeIdl,
+      tree,
+      ...utils
+    });
+
+    fs.writeFileSync(pathname, generatedPrefix(code));
+
+    audioNodes.push(nodeIdl);
   });
+}
 
-  fs.writeFileSync(pathname, generatedPrefix(code));
+{ // parse AudioContext
+  const audioContextCodeTmpl = fs.readFileSync(path.join(rsTemplates, 'audio_context.tmpl.rs'), 'utf8');
+  const audioContextTmpl = compile(audioContextCodeTmpl);
 
-  audioNodes.push(nodeIdl);
-});
+  ['AudioContext', 'OfflineAudioContext'].forEach((name, index) => {
+    const nodeIdl = findInTree(name);
+    const pathname = path.join(rsOutput, `${utils.slug(nodeIdl)}.rs`);
+    console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
 
-// parse AudioContext
-const audioContextCodeTmpl = fs.readFileSync(path.join(rsTemplates, 'audio_context.tmpl.rs'), 'utf8');
-const audioContextTmpl = compile(audioContextCodeTmpl);
+    const code = audioContextTmpl({
+      node: nodeIdl,
+      nodes: audioNodes,
+      tree,
+      ...utils
+    });
 
-['AudioContext', 'OfflineAudioContext'].forEach((name, index) => {
-  const nodeIdl = findInTree(name);
-  const pathname = path.join(rsOutput, `${utils.slug(nodeIdl)}.rs`);
-  console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
-
-  const code = audioContextTmpl({
-    node: nodeIdl,
-    nodes: audioNodes,
-    tree,
-    ...utils
+    fs.writeFileSync(pathname, generatedPrefix(code));
   });
-
-  fs.writeFileSync(pathname, generatedPrefix(code));
-});
+}
 
 // process other nodes and objects
 ['audio_param', 'audio_node', 'lib'].forEach(src => {
@@ -254,9 +261,9 @@ const audioContextTmpl = compile(audioContextCodeTmpl);
   fs.writeFileSync(pathname, generatedPrefix(code));
 });
 
-console.log('');
+console.log('-------------------------------------------------------------');
 console.log('## generating js files');
-console.log('');
+console.log('-------------------------------------------------------------');
 
 let jsTemplates = path.join(__dirname, 'js');
 let jsOutput = path.join(process.cwd(), 'js');
@@ -290,6 +297,22 @@ let jsOutput = path.join(process.cwd(), 'js');
   fs.writeFileSync(pathname, generatedPrefix(code));
 }
 
+['AudioNode', 'AudioScheduledSourceNode'].forEach((name, index) => {
+  const nodeIdl = findInTree(name);
+  const pathname = path.join(jsOutput, `${name}.mixin.js`);
+  console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
+
+  const codeTmpl = fs.readFileSync(path.join(jsTemplates, `AudioNode.mixin.tmpl.js`), 'utf8');
+  const tmpl = compile(codeTmpl);
+
+  const code = tmpl({
+    node: nodeIdl,
+    tree,
+    ...utils
+  });
+
+  fs.writeFileSync(pathname, generatedPrefix(code));
+});
 
 console.log('');
 

--- a/generator/index.mjs
+++ b/generator/index.mjs
@@ -309,6 +309,24 @@ let jsOutput = path.join(process.cwd(), 'js');
   fs.writeFileSync(pathname, generatedPrefix(code));
 }
 
+{
+  const src = 'AudioParam';
+  const nodeIdl = findInTree(src);
+  const pathname = path.join(jsOutput, `${src}.js`);
+  console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
+
+  const codeTmpl = fs.readFileSync(path.join(jsTemplates, `${src}.tmpl.js`), 'utf8');
+  const tmpl = compile(codeTmpl);
+
+  const code = tmpl({
+    node: nodeIdl,
+    tree,
+    ...utils,
+  });
+
+  fs.writeFileSync(pathname, generatedPrefix(code));
+}
+
 ['AudioNode', 'AudioScheduledSourceNode'].forEach((name, index) => {
   const nodeIdl = findInTree(name);
   const pathname = path.join(jsOutput, `${name}.mixin.js`);

--- a/generator/index.mjs
+++ b/generator/index.mjs
@@ -205,7 +205,7 @@ const nodesTmpl = compile(nodesCodeTmpl);
 supportedNodes.sort().forEach((name, index) => {
   const nodeIdl = findInTree(name);
   const pathname = path.join(rsOutput, `${utils.slug(nodeIdl)}.rs`);
-  console.log('> generating file: ', path.relative(process.cwd(), pathname));
+  console.log(`> generating file: ${path.relative(process.cwd(), pathname)}`);
 
   const code = nodesTmpl({
     node: nodeIdl,

--- a/generator/js/AudioNode.mixin.tmpl.js
+++ b/generator/js/AudioNode.mixin.tmpl.js
@@ -6,7 +6,7 @@ module.exports = (superclass) => {
 ${d.attributes(d.node).map(attr => {
   return `
     get ${d.name(attr)}() {
-      return super.${d.name(attr)}
+      return super.${d.name(attr)};
     }
 `}).join('')}
     // setters
@@ -31,7 +31,7 @@ ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
   return `
     ${d.name(method)}(...args) {
       try {
-        super.${d.name(method)}(...args);
+        return super.${d.name(method)}(...args);
       } catch (err) {
         throwSanitizedError(err);
       }

--- a/generator/js/AudioNode.mixin.tmpl.js
+++ b/generator/js/AudioNode.mixin.tmpl.js
@@ -1,5 +1,7 @@
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam, kNativeAudioParam } = require('./AudioParam.js');
+
 module.exports = (superclass) => {
   class ${d.name(d.node)} extends superclass {
     constructor(...args) {
@@ -27,7 +29,7 @@ ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
       }
     }
 `}).join('')}
-    // methods
+    // methods - connect / disconnect
     ${d.methods(d.node, false).reduce((acc, method) => {
       // dedup method names
       if (!acc.find(i => d.name(i) === d.name(method))) {
@@ -37,6 +39,11 @@ ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
     }, []).map(method => {
   return `
     ${d.name(method)}(...args) {
+      // unwrap raw audio params from facade
+      if (args[0] instanceof AudioParam) {
+        args[0] = args[0][kNativeAudioParam];
+      }
+
       try {
         return super.${d.name(method)}(...args);
       } catch (err) {
@@ -47,4 +54,4 @@ ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
   }
 
   return ${d.name(d.node)};
-}
+};

--- a/generator/js/AudioNode.mixin.tmpl.js
+++ b/generator/js/AudioNode.mixin.tmpl.js
@@ -2,6 +2,13 @@ const { throwSanitizedError } = require('./lib/errors.js');
 
 module.exports = (superclass) => {
   class ${d.name(d.node)} extends superclass {
+    constructor(...args) {
+      try {
+        super(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
     // getters
 ${d.attributes(d.node).map(attr => {
   return `

--- a/generator/js/AudioNode.mixin.tmpl.js
+++ b/generator/js/AudioNode.mixin.tmpl.js
@@ -1,0 +1,43 @@
+const { throwSanitizedError } = require('./lib/errors.js');
+
+module.exports = (superclass) => {
+  class ${d.name(d.node)} extends superclass {
+    // getters
+${d.attributes(d.node).map(attr => {
+  return `
+    get ${d.name(attr)}() {
+      return super.${d.name(attr)}
+    }
+`}).join('')}
+    // setters
+${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
+  return `
+    set ${d.name(attr)}(value) {
+      try {
+        super.${d.name(attr)} = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+`}).join('')}
+    // methods
+    ${d.methods(d.node, false).reduce((acc, method) => {
+      // dedup method names
+      if (!acc.find(i => d.name(i) === d.name(method))) {
+        acc.push(method)
+      }
+      return acc;
+    }, []).map(method => {
+  return `
+    ${d.name(method)}(...args) {
+      try {
+        super.${d.name(method)}(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+`}).join('')}
+  }
+
+  return ${d.name(d.node)};
+}

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -1,3 +1,5 @@
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 ${d.parent(d.node) === 'AudioScheduledSourceNode' ?

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -19,7 +19,7 @@ ${d.parent(d.node) === 'AudioScheduledSourceNode' ? `
       super.__initEventTarget__();
     }
 `: `
-  const EventTarget = EventTargetMixin(Native${d.name(d.node)}, ['ended']);
+  const EventTarget = EventTargetMixin(Native${d.name(d.node)});
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class ${d.name(d.node)} extends AudioNode {

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -1,5 +1,6 @@
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 ${d.parent(d.node) === 'AudioScheduledSourceNode' ?
@@ -12,17 +13,28 @@ ${d.parent(d.node) === 'AudioScheduledSourceNode' ? `
   const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
 
   class ${d.name(d.node)} extends AudioScheduledSourceNode {
-    constructor(audioContext, options) {
-      super(audioContext, options);
+    constructor(context, options) {
+      super(context, options);
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
       // bound to this, then we can safely finalize event target initialization
       super.__initEventTarget__();
+${d.audioParams(d.node).map(param => {
+    return `
+      this.${d.name(param)} = new AudioParam(this.${d.name(param)});`;
+}).join('')}
     }
 `: `
   const EventTarget = EventTargetMixin(Native${d.name(d.node)});
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class ${d.name(d.node)} extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+${d.audioParams(d.node).map(param => {
+    return `
+      this.${d.name(param)} = new AudioParam(this.${d.name(param)});`;
+}).join('')}
+    }
 `}
     // getters
 ${d.attributes(d.node).map(attr => {
@@ -62,5 +74,5 @@ ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
   }
 
   return ${d.name(d.node)};
-}
+};
 

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -1,0 +1,64 @@
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
+${d.parent(d.node) === 'AudioScheduledSourceNode' ?
+`const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');`: ``}
+
+module.exports = (Native${d.name(d.node)}) => {
+${d.parent(d.node) === 'AudioScheduledSourceNode' ? `
+  const EventTarget = EventTargetMixin(Native${d.name(d.node)}, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+  const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
+
+  class ${d.name(d.node)} extends AudioScheduledSourceNode {
+    constructor(audioContext, options) {
+      super(audioContext, options);
+      // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
+      // bound to this, then we can safely finalize event target initialization
+      super.__initEventTarget__();
+    }
+`: `
+  const EventTarget = EventTargetMixin(Native${d.name(d.node)}, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class ${d.name(d.node)} extends AudioNode {
+`}
+    // getters
+${d.attributes(d.node).map(attr => {
+  return `
+    get ${d.name(attr)}() {
+      return super.${d.name(attr)};
+    }
+`}).join('')}
+    // setters
+${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
+  return `
+    set ${d.name(attr)}(value) {
+      try {
+        super.${d.name(attr)} = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+`}).join('')}
+    // methods
+    ${d.methods(d.node, false).reduce((acc, method) => {
+      // dedup method names
+      if (!acc.find(i => d.name(i) === d.name(method))) {
+        acc.push(method)
+      }
+      return acc;
+    }, []).map(method => {
+  return `
+    ${d.name(method)}(...args) {
+      try {
+        return super.${d.name(method)}(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+`}).join('')}
+  }
+
+  return ${d.name(d.node)};
+}
+

--- a/generator/js/AudioParam.tmpl.js
+++ b/generator/js/AudioParam.tmpl.js
@@ -1,0 +1,48 @@
+const { throwSanitizedError } = require('./lib/errors.js');
+
+const kNativeAudioParam = Symbol('node-web-audio-api:audio-param');
+
+class AudioParam {
+  constructor(nativeAudioParam) {
+    this[kNativeAudioParam] = nativeAudioParam;
+  }
+
+${d.attributes(d.node).map(attr => {
+  return `
+  get ${d.name(attr)}() {
+    return this[kNativeAudioParam].${d.name(attr)};
+  }
+`}).join('')}
+    // setters
+${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
+  return `
+  set ${d.name(attr)}(value) {
+    try {
+      this[kNativeAudioParam].${d.name(attr)} = value;
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+`}).join('')}
+    // methods
+    ${d.methods(d.node, false).reduce((acc, method) => {
+      // dedup method names
+      if (!acc.find(i => d.name(i) === d.name(method))) {
+        acc.push(method)
+      }
+      return acc;
+    }, []).map(method => {
+  return `
+  ${d.name(method)}(...args) {
+    try {
+      return this[kNativeAudioParam].${d.name(method)}(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+`}).join('')}
+}
+
+module.exports.kNativeAudioParam = kNativeAudioParam;
+module.exports.AudioParam = AudioParam;
+

--- a/generator/js/BaseAudioContext.mixin.tmpl.js
+++ b/generator/js/BaseAudioContext.mixin.tmpl.js
@@ -50,7 +50,8 @@ ${args.length > 0 ? `\
 `}
     }
 `
-  }).join('\n')}}
+  }).join('\n')}
+  }
 
   return BaseAudioContext;
 };

--- a/generator/js/monkey-patch.tmpl.js
+++ b/generator/js/monkey-patch.tmpl.js
@@ -2,10 +2,10 @@ module.exports = function monkeyPatch(nativeBinding) {
   // --------------------------------------------------------------------------
   // Monkey Patch Web Audio API
   // --------------------------------------------------------------------------
-  nativeBinding.AudioBufferSourceNode = require('./AudioBufferSourceNode.js')(nativeBinding.AudioBufferSourceNode);
-  nativeBinding.ConstantSourceNode = require('./ConstantSourceNode.js')(nativeBinding.ConstantSourceNode);
-  nativeBinding.OscillatorNode = require('./OscillatorNode.js')(nativeBinding.OscillatorNode);
-
+${d.nodes.map((node) => {
+  return `
+  nativeBinding.${d.name(node)} = require('./${d.name(node)}.js')(nativeBinding.${d.name(node)});`
+}).join('')}
 
   nativeBinding.AudioContext = require('./AudioContext.js')(nativeBinding);
   nativeBinding.OfflineAudioContext = require('./OfflineAudioContext.js')(nativeBinding);
@@ -22,7 +22,7 @@ module.exports = function monkeyPatch(nativeBinding) {
   const getUserMediaSync = nativeBinding.mediaDevices.getUserMedia;
   nativeBinding.mediaDevices.getUserMedia = async function getUserMedia(options) {
     if (options === undefined) {
-      throw new TypeError(`Failed to execute 'getUserMedia' on 'MediaDevices': audio must be requested`);
+      throw new TypeError('Failed to execute "getUserMedia" on "MediaDevices": audio must be requested');
     }
 
     const stream = getUserMediaSync(options);
@@ -31,3 +31,4 @@ module.exports = function monkeyPatch(nativeBinding) {
 
   return nativeBinding;
 };
+

--- a/generator/rs/audio_context.tmpl.rs
+++ b/generator/rs/audio_context.tmpl.rs
@@ -50,6 +50,7 @@ impl ${d.napiName(d.node)} {
                 // ----------------------------------------------------
                 Property::new("baseLatency")?.with_getter(get_base_latency),
                 Property::new("outputLatency")?.with_getter(get_output_latency),
+                Property::new("sinkId")?.with_getter(get_sink_id),
                 Property::new("setSinkId")?.with_method(set_sink_id),
                 // implementation specific to online audio context
                 Property::new("resume")?.with_method(resume),
@@ -394,6 +395,16 @@ fn get_output_latency(ctx: CallContext) -> Result<JsNumber> {
 
     let output_latency = obj.output_latency();
     ctx.env.create_double(output_latency)
+}
+
+#[js_function]
+fn get_sink_id(ctx: CallContext) -> Result<JsString> {
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_obj = ctx.env.unwrap::<${d.napiName(d.node)}>(&js_this)?;
+    let obj = napi_obj.unwrap();
+
+    let sink_id = obj.sink_id();
+    ctx.env.create_string(&sink_id)
 }
 
 #[js_function(1)]

--- a/generator/rs/audio_context.tmpl.rs
+++ b/generator/rs/audio_context.tmpl.rs
@@ -176,9 +176,9 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     // -------------------------------------------------
     // Parse options and create OfflineAudioContext
     // -------------------------------------------------
-    let number_of_channels = ctx.get::<JsNumber>(0)?.get_double()? as usize;
-    let length = ctx.get::<JsNumber>(1)?.get_double()? as usize;
-    let sample_rate = ctx.get::<JsNumber>(2)?.get_double()? as f32;
+    let number_of_channels = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as usize;
+    let length = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()? as usize;
+    let sample_rate = ctx.get::<JsObject>(2)?.coerce_to_number()?.get_double()? as f32;
 
     let audio_context = ${d.name(d.node)}::new(number_of_channels, length, sample_rate);
         `}

--- a/generator/rs/audio_nodes.tmpl.rs
+++ b/generator/rs/audio_nodes.tmpl.rs
@@ -91,22 +91,26 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name = js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) = js_audio_context.has_named_property("Symbol.toStringTag") {
+        if result {
+            let audio_context_name = js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct '${d.name(d.node)}': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct '${d.name(d.node)}': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct '${d.name(d.node)}': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/generator/rs/audio_nodes.tmpl.rs
+++ b/generator/rs/audio_nodes.tmpl.rs
@@ -294,7 +294,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                         "max" => ChannelCountMode::Max,
                         "clamped-max" => ChannelCountMode::ClampedMax,
                         "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
                     }
                 } else {
                     channel_config_defaults.count_mode
@@ -307,7 +307,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                     match channel_interpretation_str.as_str() {
                         "speakers" => ChannelInterpretation::Speakers,
                         "discrete" => ChannelInterpretation::Discrete,
-                        _ => panic!("undefined value for ChannelInterpretation"),
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
                     }
                 } else {
                     channel_config_defaults.interpretation
@@ -327,7 +327,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
             Either::B(_) => {
                 ${argumentIdl.members.reduce((acc, current) => acc || current.required, false) ? `
                     return Err(napi::Error::from_reason(
-                        "Options are mandatory for node ${d.name(d.node)}".to_string(),
+                        "TypeError - Options are mandatory for node ${d.name(d.node)}".to_string(),
                     ));
                 ` : `
                     Default::default()
@@ -337,7 +337,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     } else {
         ${argumentIdl.members.reduce((acc, current) => acc || current.required, false) ? `
             return Err(napi::Error::from_reason(
-                "Options are mandatory for node ${d.name(d.node)}".to_string(),
+                "TypeError - Options are mandatory for node ${d.name(d.node)}".to_string(),
             ));
         ` : `
             Default::default()
@@ -435,7 +435,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -468,7 +468,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/generator/rs/audio_nodes.tmpl.rs
+++ b/generator/rs/audio_nodes.tmpl.rs
@@ -89,8 +89,10 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) = js_audio_context.get_named_property::<JsString>("Symbol.toStringTag") {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name = js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/generator/rs/audio_param.tmpl.rs
+++ b/generator/rs/audio_param.tmpl.rs
@@ -68,10 +68,10 @@ fn get_automation_rate(ctx: CallContext) -> Result<JsString> {
 fn set_automation_rate(ctx: CallContext) -> Result<JsUndefined> {
     let js_this = ctx.this_unchecked::<JsObject>();
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
-    let obj = napi_obj.unwrap();
+    let obj = &mut napi_obj.0;
 
-    let js_str = ctx.get::<JsString>(0)?;
-    let utf8_str = js_str.into_utf8()?.into_owned()?;
+    let js_str = ctx.get::<JsObject>(0)?;
+    let utf8_str = js_str.coerce_to_string()?.into_utf8()?.into_owned()?;
     let value = match utf8_str.as_str() {
         "a-rate" => AutomationRate::A,
         "k-rate" => AutomationRate::K,
@@ -128,7 +128,7 @@ fn set_value(ctx: CallContext) -> Result<JsUndefined> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
     obj.set_value(value);
 
     ctx.env.get_undefined()
@@ -141,8 +141,8 @@ fn set_value_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
-    let start_time = ctx.get::<JsNumber>(1)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
+    let start_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
     obj.set_value_at_time(value as f32, start_time);
 
     Ok(js_this)
@@ -154,8 +154,8 @@ fn linear_ramp_to_value_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
-    let end_time = ctx.get::<JsNumber>(1)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
+    let end_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
     obj.linear_ramp_to_value_at_time(value, end_time);
 
     Ok(js_this)
@@ -167,8 +167,8 @@ fn exponential_ramp_to_value_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
-    let end_time = ctx.get::<JsNumber>(1)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
+    let end_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
     obj.exponential_ramp_to_value_at_time(value, end_time);
 
     Ok(js_this)
@@ -183,8 +183,8 @@ fn set_value_curve_at_time(ctx: CallContext) -> Result<JsObject> {
     let mut typed_array_values = ctx.get::<JsTypedArray>(0)?.into_value()?;
     let values: &mut [f32] = typed_array_values.as_mut();
 
-    let start_time = ctx.get::<JsNumber>(1)?.get_double()?;
-    let duration = ctx.get::<JsNumber>(2)?.get_double()?;
+    let start_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
+    let duration = ctx.get::<JsObject>(2)?.coerce_to_number()?.get_double()?;
     obj.set_value_curve_at_time(values, start_time, duration);
 
     Ok(js_this)
@@ -196,9 +196,9 @@ fn set_target_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
-    let start_time = ctx.get::<JsNumber>(1)?.get_double()?;
-    let time_constant = ctx.get::<JsNumber>(2)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
+    let start_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
+    let time_constant = ctx.get::<JsObject>(2)?.coerce_to_number()?.get_double()?;
     obj.set_target_at_time(value, start_time, time_constant);
 
     Ok(js_this)
@@ -210,7 +210,7 @@ fn cancel_scheduled_values(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let cancel_time = ctx.get::<JsNumber>(0)?.get_double()?;
+    let cancel_time = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     obj.cancel_scheduled_values(cancel_time);
 
     Ok(js_this)
@@ -222,7 +222,7 @@ fn cancel_and_hold_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let cancel_time = ctx.get::<JsNumber>(0)?.get_double()?;
+    let cancel_time = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     obj.cancel_and_hold_at_time(cancel_time);
 
     Ok(js_this)

--- a/generator/rs/lib.tmpl.rs
+++ b/generator/rs/lib.tmpl.rs
@@ -51,20 +51,8 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[module_exports]
 fn init(mut exports: JsObject, env: Env) -> Result<()> {
-    // @todo - catch all panics and throw clean JS Error
-    // do not uncomment until it is clean as it swallow the error message and
-    // makes things event more complicated...
-    //
-    // std::panic::set_hook(Box::new(|panic_info| {
-    //     println!("{:?}", panic_info.payload());
-
-    //     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-    //         println!("panic occurred: {s:?}");
-    //     } else {
-    //         println!("panic occurred");
-    //     }
-    // }));
-
+    // Do not print panic messages, handle through JS errors
+    std::panic::set_hook(Box::new(|_panic_info| {}));
 
     // Store constructors for factory methods and internal instantiations
     // Note that we need to create the js class twice so that export and store

--- a/index.cjs
+++ b/index.cjs
@@ -83,7 +83,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding for OS: ${platform}, architecture: ${arch}`);
 }
 
-const monkeyPatch = require('./js/index.js');
+const monkeyPatch = require('./js/monkey-patch.js');
 nativeBinding = monkeyPatch(nativeBinding);
 
 module.exports = nativeBinding;

--- a/js/AnalyserNode.js
+++ b/js/AnalyserNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,10 @@ module.exports = (NativeAnalyserNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class AnalyserNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+    }
 
     // getters
 
@@ -123,7 +128,7 @@ module.exports = (NativeAnalyserNode) => {
   }
 
   return AnalyserNode;
-}
+};
 
 
   

--- a/js/AnalyserNode.js
+++ b/js/AnalyserNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/AnalyserNode.js
+++ b/js/AnalyserNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeAnalyserNode) => {
 
-  const EventTarget = EventTargetMixin(NativeAnalyserNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeAnalyserNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class AnalyserNode extends AudioNode {

--- a/js/AnalyserNode.js
+++ b/js/AnalyserNode.js
@@ -17,57 +17,68 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeAnalyserNode) => {
+
+  const EventTarget = EventTargetMixin(NativeAnalyserNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class AnalyserNode extends AudioNode {
+
     // getters
 
-    get context() {
-      return super.context;
+    get fftSize() {
+      return super.fftSize;
     }
 
-    get numberOfInputs() {
-      return super.numberOfInputs;
+    get frequencyBinCount() {
+      return super.frequencyBinCount;
     }
 
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
+    get minDecibels() {
+      return super.minDecibels;
     }
 
-    get channelCount() {
-      return super.channelCount;
+    get maxDecibels() {
+      return super.maxDecibels;
     }
 
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
+    get smoothingTimeConstant() {
+      return super.smoothingTimeConstant;
     }
 
     // setters
 
-    set channelCount(value) {
+    set fftSize(value) {
       try {
-        super.channelCount = value;
+        super.fftSize = value;
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    set channelCountMode(value) {
+    set minDecibels(value) {
       try {
-        super.channelCountMode = value;
+        super.minDecibels = value;
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    set channelInterpretation(value) {
+    set maxDecibels(value) {
       try {
-        super.channelInterpretation = value;
+        super.maxDecibels = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set smoothingTimeConstant(value) {
+      try {
+        super.smoothingTimeConstant = value;
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -75,17 +86,33 @@ module.exports = (superclass) => {
 
     // methods
     
-    connect(...args) {
+    getFloatFrequencyData(...args) {
       try {
-        return super.connect(...args);
+        return super.getFloatFrequencyData(...args);
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    disconnect(...args) {
+    getByteFrequencyData(...args) {
       try {
-        return super.disconnect(...args);
+        return super.getByteFrequencyData(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    getFloatTimeDomainData(...args) {
+      try {
+        return super.getFloatTimeDomainData(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    getByteTimeDomainData(...args) {
+      try {
+        return super.getByteTimeDomainData(...args);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -93,7 +120,8 @@ module.exports = (superclass) => {
 
   }
 
-  return AudioNode;
+  return AnalyserNode;
 }
+
 
   

--- a/js/AudioBufferSourceNode.js
+++ b/js/AudioBufferSourceNode.js
@@ -1,8 +1,33 @@
-const EventTargetMixin = require('./EventTarget.mixin.js');
-const { throwSanitizedError } = require('./lib/errors.js');
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+//                                                                            //
+//                                                                            //
+//                                                                            //
+//    ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗               //
+//    ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝               //
+//    ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗              //
+//    ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║              //
+//    ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝              //
+//     ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝               //
+//                                                                            //
+//                                                                            //
+//    - This file has been generated ---------------------------              //
+//                                                                            //
+//                                                                            //
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
 
-module.exports = function(NativeAudioBufferSourceNode) {
-  class AudioBufferSourceNode extends EventTargetMixin(NativeAudioBufferSourceNode, ['ended']) {
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
+const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');
+
+module.exports = (NativeAudioBufferSourceNode) => {
+
+  const EventTarget = EventTargetMixin(NativeAudioBufferSourceNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+  const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
+
+  class AudioBufferSourceNode extends AudioScheduledSourceNode {
     constructor(audioContext, options) {
       super(audioContext, options);
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
@@ -10,17 +35,72 @@ module.exports = function(NativeAudioBufferSourceNode) {
       super.__initEventTarget__();
     }
 
-    // setters can fail too, e.g.
-    // src.buffer = 'test';
+    // getters
 
-    start(...args) {
+    get buffer() {
+      return super.buffer;
+    }
+
+    get loop() {
+      return super.loop;
+    }
+
+    get loopStart() {
+      return super.loopStart;
+    }
+
+    get loopEnd() {
+      return super.loopEnd;
+    }
+
+    // setters
+
+    set buffer(value) {
       try {
-        super.start(...args);
+        super.buffer = value;
       } catch (err) {
         throwSanitizedError(err);
       }
     }
+
+    set loop(value) {
+      try {
+        super.loop = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set loopStart(value) {
+      try {
+        super.loopStart = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set loopEnd(value) {
+      try {
+        super.loopEnd = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    // methods
+    
+    start(...args) {
+      try {
+        return super.start(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
   }
 
   return AudioBufferSourceNode;
-};
+}
+
+
+  

--- a/js/AudioBufferSourceNode.js
+++ b/js/AudioBufferSourceNode.js
@@ -1,4 +1,5 @@
 const EventTargetMixin = require('./EventTarget.mixin.js');
+const { errorHandler, throwSanitizedError } = require('./lib/errors.js');
 
 module.exports = function(NativeAudioBufferSourceNode) {
   class AudioBufferSourceNode extends EventTargetMixin(NativeAudioBufferSourceNode, ['ended']) {
@@ -7,6 +8,14 @@ module.exports = function(NativeAudioBufferSourceNode) {
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
       // bound to this, then we can safely finalize event target initialization
       super.__initEventTarget__();
+    }
+
+    start(when) {
+      try {
+        super.start(when);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
     }
   }
 

--- a/js/AudioBufferSourceNode.js
+++ b/js/AudioBufferSourceNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');
@@ -30,11 +31,14 @@ module.exports = (NativeAudioBufferSourceNode) => {
   const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
 
   class AudioBufferSourceNode extends AudioScheduledSourceNode {
-    constructor(audioContext, options) {
-      super(audioContext, options);
+    constructor(context, options) {
+      super(context, options);
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
       // bound to this, then we can safely finalize event target initialization
       super.__initEventTarget__();
+
+      this.playbackRate = new AudioParam(this.playbackRate);
+      this.detune = new AudioParam(this.detune);
     }
 
     // getters
@@ -102,7 +106,7 @@ module.exports = (NativeAudioBufferSourceNode) => {
   }
 
   return AudioBufferSourceNode;
-}
+};
 
 
   

--- a/js/AudioBufferSourceNode.js
+++ b/js/AudioBufferSourceNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');

--- a/js/AudioBufferSourceNode.js
+++ b/js/AudioBufferSourceNode.js
@@ -1,5 +1,5 @@
 const EventTargetMixin = require('./EventTarget.mixin.js');
-const { errorHandler, throwSanitizedError } = require('./lib/errors.js');
+const { throwSanitizedError } = require('./lib/errors.js');
 
 module.exports = function(NativeAudioBufferSourceNode) {
   class AudioBufferSourceNode extends EventTargetMixin(NativeAudioBufferSourceNode, ['ended']) {
@@ -10,9 +10,12 @@ module.exports = function(NativeAudioBufferSourceNode) {
       super.__initEventTarget__();
     }
 
-    start(when) {
+    // setters can fail too, e.g.
+    // src.buffer = 'test';
+
+    start(...args) {
       try {
-        super.start(when);
+        super.start(...args);
       } catch (err) {
         throwSanitizedError(err);
       }

--- a/js/AudioContext.js
+++ b/js/AudioContext.js
@@ -5,7 +5,7 @@ const kKeepAwakeId = Symbol('keepAwakeId');
 
 module.exports = function(bindings) {
   const {
-    MediaStreamAudioSourceNode
+    MediaStreamAudioSourceNode,
   } = bindings;
 
   const EventTarget = require('./EventTarget.mixin.js')(bindings.AudioContext, ['statechange', 'sinkchange']);

--- a/js/AudioNode.mixin.js
+++ b/js/AudioNode.mixin.js
@@ -19,6 +19,8 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam, kNativeAudioParam } = require('./AudioParam.js');
+
 module.exports = (superclass) => {
   class AudioNode extends superclass {
     constructor(...args) {
@@ -80,9 +82,14 @@ module.exports = (superclass) => {
       }
     }
 
-    // methods
+    // methods - connect / disconnect
     
     connect(...args) {
+      // unwrap raw audio params from facade
+      if (args[0] instanceof AudioParam) {
+        args[0] = args[0][kNativeAudioParam];
+      }
+
       try {
         return super.connect(...args);
       } catch (err) {
@@ -91,6 +98,11 @@ module.exports = (superclass) => {
     }
 
     disconnect(...args) {
+      // unwrap raw audio params from facade
+      if (args[0] instanceof AudioParam) {
+        args[0] = args[0][kNativeAudioParam];
+      }
+
       try {
         return super.disconnect(...args);
       } catch (err) {
@@ -101,6 +113,6 @@ module.exports = (superclass) => {
   }
 
   return AudioNode;
-}
+};
 
   

--- a/js/AudioNode.mixin.js
+++ b/js/AudioNode.mixin.js
@@ -1,0 +1,99 @@
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+//                                                                            //
+//                                                                            //
+//                                                                            //
+//    ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗               //
+//    ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝               //
+//    ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗              //
+//    ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║              //
+//    ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝              //
+//     ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝               //
+//                                                                            //
+//                                                                            //
+//    - This file has been generated ---------------------------              //
+//                                                                            //
+//                                                                            //
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+
+const { throwSanitizedError } = require('./lib/errors.js');
+
+module.exports = (superclass) => {
+  class AudioNode extends superclass {
+    // getters
+
+    get context() {
+      return super.context
+    }
+
+    get numberOfInputs() {
+      return super.numberOfInputs
+    }
+
+    get numberOfOutputs() {
+      return super.numberOfOutputs
+    }
+
+    get channelCount() {
+      return super.channelCount
+    }
+
+    get channelCountMode() {
+      return super.channelCountMode
+    }
+
+    get channelInterpretation() {
+      return super.channelInterpretation
+    }
+
+    // setters
+
+    set channelCount(value) {
+      try {
+        super.channelCount = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set channelCountMode(value) {
+      try {
+        super.channelCountMode = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set channelInterpretation(value) {
+      try {
+        super.channelInterpretation = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    // methods
+    
+    connect(...args) {
+      try {
+        super.connect(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    disconnect(...args) {
+      try {
+        super.disconnect(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+  }
+
+  return AudioNode;
+}
+
+  

--- a/js/AudioNode.mixin.js
+++ b/js/AudioNode.mixin.js
@@ -21,6 +21,13 @@ const { throwSanitizedError } = require('./lib/errors.js');
 
 module.exports = (superclass) => {
   class AudioNode extends superclass {
+    constructor(...args) {
+      try {
+        super(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
     // getters
 
     get context() {

--- a/js/AudioParam.js
+++ b/js/AudioParam.js
@@ -19,56 +19,114 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
-const { AudioParam } = require('./AudioParam.js');
-const EventTargetMixin = require('./EventTarget.mixin.js');
-const AudioNodeMixin = require('./AudioNode.mixin.js');
+const kNativeAudioParam = Symbol('node-web-audio-api:audio-param');
+
+class AudioParam {
+  constructor(nativeAudioParam) {
+    this[kNativeAudioParam] = nativeAudioParam;
+  }
 
 
-module.exports = (NativeConvolverNode) => {
+  get value() {
+    return this[kNativeAudioParam].value;
+  }
 
-  const EventTarget = EventTargetMixin(NativeConvolverNode);
-  const AudioNode = AudioNodeMixin(EventTarget);
+  get automationRate() {
+    return this[kNativeAudioParam].automationRate;
+  }
 
-  class ConvolverNode extends AudioNode {
-    constructor(context, options) {
-      super(context, options);
+  get defaultValue() {
+    return this[kNativeAudioParam].defaultValue;
+  }
 
-    }
+  get minValue() {
+    return this[kNativeAudioParam].minValue;
+  }
 
-    // getters
-
-    get buffer() {
-      return super.buffer;
-    }
-
-    get normalize() {
-      return super.normalize;
-    }
+  get maxValue() {
+    return this[kNativeAudioParam].maxValue;
+  }
 
     // setters
 
-    set buffer(value) {
-      try {
-        super.buffer = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
+  set value(value) {
+    try {
+      this[kNativeAudioParam].value = value;
+    } catch (err) {
+      throwSanitizedError(err);
     }
+  }
 
-    set normalize(value) {
-      try {
-        super.normalize = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
+  set automationRate(value) {
+    try {
+      this[kNativeAudioParam].automationRate = value;
+    } catch (err) {
+      throwSanitizedError(err);
     }
+  }
 
     // methods
     
+  setValueAtTime(...args) {
+    try {
+      return this[kNativeAudioParam].setValueAtTime(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
   }
 
-  return ConvolverNode;
-};
+  linearRampToValueAtTime(...args) {
+    try {
+      return this[kNativeAudioParam].linearRampToValueAtTime(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+
+  exponentialRampToValueAtTime(...args) {
+    try {
+      return this[kNativeAudioParam].exponentialRampToValueAtTime(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+
+  setTargetAtTime(...args) {
+    try {
+      return this[kNativeAudioParam].setTargetAtTime(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+
+  setValueCurveAtTime(...args) {
+    try {
+      return this[kNativeAudioParam].setValueCurveAtTime(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+
+  cancelScheduledValues(...args) {
+    try {
+      return this[kNativeAudioParam].cancelScheduledValues(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+
+  cancelAndHoldAtTime(...args) {
+    try {
+      return this[kNativeAudioParam].cancelAndHoldAtTime(...args);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+  }
+
+}
+
+module.exports.kNativeAudioParam = kNativeAudioParam;
+module.exports.AudioParam = AudioParam;
 
 
   

--- a/js/AudioScheduledSourceNode.mixin.js
+++ b/js/AudioScheduledSourceNode.mixin.js
@@ -1,0 +1,63 @@
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+//                                                                            //
+//                                                                            //
+//                                                                            //
+//    ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗               //
+//    ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝               //
+//    ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗              //
+//    ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║              //
+//    ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝              //
+//     ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝               //
+//                                                                            //
+//                                                                            //
+//    - This file has been generated ---------------------------              //
+//                                                                            //
+//                                                                            //
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+
+const { throwSanitizedError } = require('./lib/errors.js');
+
+module.exports = (superclass) => {
+  class AudioScheduledSourceNode extends superclass {
+    // getters
+
+    get onended() {
+      return super.onended
+    }
+
+    // setters
+
+    set onended(value) {
+      try {
+        super.onended = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    // methods
+    
+    start(...args) {
+      try {
+        super.start(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    stop(...args) {
+      try {
+        super.stop(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+  }
+
+  return AudioScheduledSourceNode;
+}
+
+  

--- a/js/AudioScheduledSourceNode.mixin.js
+++ b/js/AudioScheduledSourceNode.mixin.js
@@ -24,7 +24,7 @@ module.exports = (superclass) => {
     // getters
 
     get onended() {
-      return super.onended
+      return super.onended;
     }
 
     // setters
@@ -41,7 +41,7 @@ module.exports = (superclass) => {
     
     start(...args) {
       try {
-        super.start(...args);
+        return super.start(...args);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -49,7 +49,7 @@ module.exports = (superclass) => {
 
     stop(...args) {
       try {
-        super.stop(...args);
+        return super.stop(...args);
       } catch (err) {
         throwSanitizedError(err);
       }

--- a/js/AudioScheduledSourceNode.mixin.js
+++ b/js/AudioScheduledSourceNode.mixin.js
@@ -21,6 +21,13 @@ const { throwSanitizedError } = require('./lib/errors.js');
 
 module.exports = (superclass) => {
   class AudioScheduledSourceNode extends superclass {
+    constructor(...args) {
+      try {
+        super(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
     // getters
 
     get onended() {

--- a/js/AudioScheduledSourceNode.mixin.js
+++ b/js/AudioScheduledSourceNode.mixin.js
@@ -19,6 +19,8 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam, kNativeAudioParam } = require('./AudioParam.js');
+
 module.exports = (superclass) => {
   class AudioScheduledSourceNode extends superclass {
     constructor(...args) {
@@ -44,9 +46,14 @@ module.exports = (superclass) => {
       }
     }
 
-    // methods
+    // methods - connect / disconnect
     
     start(...args) {
+      // unwrap raw audio params from facade
+      if (args[0] instanceof AudioParam) {
+        args[0] = args[0][kNativeAudioParam];
+      }
+
       try {
         return super.start(...args);
       } catch (err) {
@@ -55,6 +62,11 @@ module.exports = (superclass) => {
     }
 
     stop(...args) {
+      // unwrap raw audio params from facade
+      if (args[0] instanceof AudioParam) {
+        args[0] = args[0][kNativeAudioParam];
+      }
+
       try {
         return super.stop(...args);
       } catch (err) {
@@ -65,6 +77,6 @@ module.exports = (superclass) => {
   }
 
   return AudioScheduledSourceNode;
-}
+};
 
   

--- a/js/BaseAudioContext.mixin.js
+++ b/js/BaseAudioContext.mixin.js
@@ -131,7 +131,8 @@ module.exports = (superclass, bindings) => {
     createWaveShaper() {
       return new WaveShaperNode(this);
     }
-}
+
+  }
 
   return BaseAudioContext;
 };

--- a/js/BiquadFilterNode.js
+++ b/js/BiquadFilterNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeBiquadFilterNode) => {
 
-  const EventTarget = EventTargetMixin(NativeBiquadFilterNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeBiquadFilterNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class BiquadFilterNode extends AudioNode {

--- a/js/BiquadFilterNode.js
+++ b/js/BiquadFilterNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/BiquadFilterNode.js
+++ b/js/BiquadFilterNode.js
@@ -17,57 +17,28 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeBiquadFilterNode) => {
+
+  const EventTarget = EventTargetMixin(NativeBiquadFilterNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class BiquadFilterNode extends AudioNode {
+
     // getters
 
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
+    get type() {
+      return super.type;
     }
 
     // setters
 
-    set channelCount(value) {
+    set type(value) {
       try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
+        super.type = value;
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -75,17 +46,9 @@ module.exports = (superclass) => {
 
     // methods
     
-    connect(...args) {
+    getFrequencyResponse(...args) {
       try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
+        return super.getFrequencyResponse(...args);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -93,7 +56,8 @@ module.exports = (superclass) => {
 
   }
 
-  return AudioNode;
+  return BiquadFilterNode;
 }
+
 
   

--- a/js/BiquadFilterNode.js
+++ b/js/BiquadFilterNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,14 @@ module.exports = (NativeBiquadFilterNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class BiquadFilterNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+      this.frequency = new AudioParam(this.frequency);
+      this.detune = new AudioParam(this.detune);
+      this.Q = new AudioParam(this.Q);
+      this.gain = new AudioParam(this.gain);
+    }
 
     // getters
 
@@ -59,7 +68,7 @@ module.exports = (NativeBiquadFilterNode) => {
   }
 
   return BiquadFilterNode;
-}
+};
 
 
   

--- a/js/ChannelMergerNode.js
+++ b/js/ChannelMergerNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/ChannelMergerNode.js
+++ b/js/ChannelMergerNode.js
@@ -17,83 +17,27 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeChannelMergerNode) => {
+
+  const EventTarget = EventTargetMixin(NativeChannelMergerNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class ChannelMergerNode extends AudioNode {
+
     // getters
-
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
-    }
 
     // setters
 
-    set channelCount(value) {
-      try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return ChannelMergerNode;
 }
+
 
   

--- a/js/ChannelMergerNode.js
+++ b/js/ChannelMergerNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeChannelMergerNode) => {
 
-  const EventTarget = EventTargetMixin(NativeChannelMergerNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeChannelMergerNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class ChannelMergerNode extends AudioNode {

--- a/js/ChannelMergerNode.js
+++ b/js/ChannelMergerNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,10 @@ module.exports = (NativeChannelMergerNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class ChannelMergerNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+    }
 
     // getters
 
@@ -39,7 +44,7 @@ module.exports = (NativeChannelMergerNode) => {
   }
 
   return ChannelMergerNode;
-}
+};
 
 
   

--- a/js/ChannelSplitterNode.js
+++ b/js/ChannelSplitterNode.js
@@ -17,83 +17,27 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeChannelSplitterNode) => {
+
+  const EventTarget = EventTargetMixin(NativeChannelSplitterNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class ChannelSplitterNode extends AudioNode {
+
     // getters
-
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
-    }
 
     // setters
 
-    set channelCount(value) {
-      try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return ChannelSplitterNode;
 }
+
 
   

--- a/js/ChannelSplitterNode.js
+++ b/js/ChannelSplitterNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/ChannelSplitterNode.js
+++ b/js/ChannelSplitterNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,10 @@ module.exports = (NativeChannelSplitterNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class ChannelSplitterNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+    }
 
     // getters
 
@@ -39,7 +44,7 @@ module.exports = (NativeChannelSplitterNode) => {
   }
 
   return ChannelSplitterNode;
-}
+};
 
 
   

--- a/js/ChannelSplitterNode.js
+++ b/js/ChannelSplitterNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeChannelSplitterNode) => {
 
-  const EventTarget = EventTargetMixin(NativeChannelSplitterNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeChannelSplitterNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class ChannelSplitterNode extends AudioNode {

--- a/js/ConstantSourceNode.js
+++ b/js/ConstantSourceNode.js
@@ -1,15 +1,50 @@
-const EventTargetMixin = require('./EventTarget.mixin.js');
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+//                                                                            //
+//                                                                            //
+//                                                                            //
+//    ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗               //
+//    ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝               //
+//    ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗              //
+//    ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║              //
+//    ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝              //
+//     ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝               //
+//                                                                            //
+//                                                                            //
+//    - This file has been generated ---------------------------              //
+//                                                                            //
+//                                                                            //
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
 
-module.exports = function(NativeConstantSourceNode) {
-  class ConstantSourceNode extends EventTargetMixin(NativeConstantSourceNode, ['ended']) {
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
+const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');
+
+module.exports = (NativeConstantSourceNode) => {
+
+  const EventTarget = EventTargetMixin(NativeConstantSourceNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+  const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
+
+  class ConstantSourceNode extends AudioScheduledSourceNode {
     constructor(audioContext, options) {
       super(audioContext, options);
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
       // bound to this, then we can safely finalize event target initialization
       super.__initEventTarget__();
     }
+
+    // getters
+
+    // setters
+
+    // methods
+    
   }
 
   return ConstantSourceNode;
-};
+}
 
+
+  

--- a/js/ConstantSourceNode.js
+++ b/js/ConstantSourceNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');
@@ -30,11 +31,13 @@ module.exports = (NativeConstantSourceNode) => {
   const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
 
   class ConstantSourceNode extends AudioScheduledSourceNode {
-    constructor(audioContext, options) {
-      super(audioContext, options);
+    constructor(context, options) {
+      super(context, options);
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
       // bound to this, then we can safely finalize event target initialization
       super.__initEventTarget__();
+
+      this.offset = new AudioParam(this.offset);
     }
 
     // getters
@@ -46,7 +49,7 @@ module.exports = (NativeConstantSourceNode) => {
   }
 
   return ConstantSourceNode;
-}
+};
 
 
   

--- a/js/ConstantSourceNode.js
+++ b/js/ConstantSourceNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');

--- a/js/ConvolverNode.js
+++ b/js/ConvolverNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/ConvolverNode.js
+++ b/js/ConvolverNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeConvolverNode) => {
 
-  const EventTarget = EventTargetMixin(NativeConvolverNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeConvolverNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class ConvolverNode extends AudioNode {

--- a/js/ConvolverNode.js
+++ b/js/ConvolverNode.js
@@ -17,57 +17,40 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeConvolverNode) => {
+
+  const EventTarget = EventTargetMixin(NativeConvolverNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class ConvolverNode extends AudioNode {
+
     // getters
 
-    get context() {
-      return super.context;
+    get buffer() {
+      return super.buffer;
     }
 
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
+    get normalize() {
+      return super.normalize;
     }
 
     // setters
 
-    set channelCount(value) {
+    set buffer(value) {
       try {
-        super.channelCount = value;
+        super.buffer = value;
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    set channelCountMode(value) {
+    set normalize(value) {
       try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
+        super.normalize = value;
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -75,25 +58,10 @@ module.exports = (superclass) => {
 
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return ConvolverNode;
 }
+
 
   

--- a/js/DelayNode.js
+++ b/js/DelayNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/DelayNode.js
+++ b/js/DelayNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,11 @@ module.exports = (NativeDelayNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class DelayNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+      this.delayTime = new AudioParam(this.delayTime);
+    }
 
     // getters
 
@@ -39,7 +45,7 @@ module.exports = (NativeDelayNode) => {
   }
 
   return DelayNode;
-}
+};
 
 
   

--- a/js/DelayNode.js
+++ b/js/DelayNode.js
@@ -17,83 +17,27 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeDelayNode) => {
+
+  const EventTarget = EventTargetMixin(NativeDelayNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class DelayNode extends AudioNode {
+
     // getters
-
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
-    }
 
     // setters
 
-    set channelCount(value) {
-      try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return DelayNode;
 }
+
 
   

--- a/js/DelayNode.js
+++ b/js/DelayNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeDelayNode) => {
 
-  const EventTarget = EventTargetMixin(NativeDelayNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeDelayNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class DelayNode extends AudioNode {

--- a/js/DynamicsCompressorNode.js
+++ b/js/DynamicsCompressorNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/DynamicsCompressorNode.js
+++ b/js/DynamicsCompressorNode.js
@@ -17,83 +17,31 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeDynamicsCompressorNode) => {
+
+  const EventTarget = EventTargetMixin(NativeDynamicsCompressorNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class DynamicsCompressorNode extends AudioNode {
+
     // getters
 
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
+    get reduction() {
+      return super.reduction;
     }
 
     // setters
 
-    set channelCount(value) {
-      try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return DynamicsCompressorNode;
 }
+
 
   

--- a/js/DynamicsCompressorNode.js
+++ b/js/DynamicsCompressorNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,15 @@ module.exports = (NativeDynamicsCompressorNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class DynamicsCompressorNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+      this.threshold = new AudioParam(this.threshold);
+      this.knee = new AudioParam(this.knee);
+      this.ratio = new AudioParam(this.ratio);
+      this.attack = new AudioParam(this.attack);
+      this.release = new AudioParam(this.release);
+    }
 
     // getters
 
@@ -43,7 +53,7 @@ module.exports = (NativeDynamicsCompressorNode) => {
   }
 
   return DynamicsCompressorNode;
-}
+};
 
 
   

--- a/js/DynamicsCompressorNode.js
+++ b/js/DynamicsCompressorNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeDynamicsCompressorNode) => {
 
-  const EventTarget = EventTargetMixin(NativeDynamicsCompressorNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeDynamicsCompressorNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class DynamicsCompressorNode extends AudioNode {

--- a/js/EventTarget.mixin.js
+++ b/js/EventTarget.mixin.js
@@ -3,7 +3,7 @@ const { isFunction } = require('./lib/utils.js');
 const kEventListeners = Symbol('node-web-audio-api:event-listeners');
 const kDispatchEvent = Symbol.for('node-web-audio-api:napi-dispatch-event');
 
-module.exports = (superclass, eventTypes) => class EventTarget extends superclass {
+module.exports = (superclass, eventTypes = []) => class EventTarget extends superclass {
   [kEventListeners] = new Map();
 
   constructor(...args) {

--- a/js/GainNode.js
+++ b/js/GainNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/GainNode.js
+++ b/js/GainNode.js
@@ -17,83 +17,27 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeGainNode) => {
+
+  const EventTarget = EventTargetMixin(NativeGainNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class GainNode extends AudioNode {
+
     // getters
-
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
-    }
 
     // setters
 
-    set channelCount(value) {
-      try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return GainNode;
 }
+
 
   

--- a/js/GainNode.js
+++ b/js/GainNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeGainNode) => {
 
-  const EventTarget = EventTargetMixin(NativeGainNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeGainNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class GainNode extends AudioNode {

--- a/js/GainNode.js
+++ b/js/GainNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,11 @@ module.exports = (NativeGainNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class GainNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+      this.gain = new AudioParam(this.gain);
+    }
 
     // getters
 
@@ -39,7 +45,7 @@ module.exports = (NativeGainNode) => {
   }
 
   return GainNode;
-}
+};
 
 
   

--- a/js/IIRFilterNode.js
+++ b/js/IIRFilterNode.js
@@ -17,75 +17,26 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeIIRFilterNode) => {
+
+  const EventTarget = EventTargetMixin(NativeIIRFilterNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class IIRFilterNode extends AudioNode {
+
     // getters
-
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
-    }
 
     // setters
 
-    set channelCount(value) {
-      try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
     // methods
     
-    connect(...args) {
+    getFrequencyResponse(...args) {
       try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
+        return super.getFrequencyResponse(...args);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -93,7 +44,8 @@ module.exports = (superclass) => {
 
   }
 
-  return AudioNode;
+  return IIRFilterNode;
 }
+
 
   

--- a/js/IIRFilterNode.js
+++ b/js/IIRFilterNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeIIRFilterNode) => {
 
-  const EventTarget = EventTargetMixin(NativeIIRFilterNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeIIRFilterNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class IIRFilterNode extends AudioNode {

--- a/js/IIRFilterNode.js
+++ b/js/IIRFilterNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,10 @@ module.exports = (NativeIIRFilterNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class IIRFilterNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+    }
 
     // getters
 
@@ -47,7 +52,7 @@ module.exports = (NativeIIRFilterNode) => {
   }
 
   return IIRFilterNode;
-}
+};
 
 
   

--- a/js/IIRFilterNode.js
+++ b/js/IIRFilterNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/OscillatorNode.js
+++ b/js/OscillatorNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');
@@ -30,11 +31,14 @@ module.exports = (NativeOscillatorNode) => {
   const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
 
   class OscillatorNode extends AudioScheduledSourceNode {
-    constructor(audioContext, options) {
-      super(audioContext, options);
+    constructor(context, options) {
+      super(context, options);
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
       // bound to this, then we can safely finalize event target initialization
       super.__initEventTarget__();
+
+      this.frequency = new AudioParam(this.frequency);
+      this.detune = new AudioParam(this.detune);
     }
 
     // getters
@@ -66,7 +70,7 @@ module.exports = (NativeOscillatorNode) => {
   }
 
   return OscillatorNode;
-}
+};
 
 
   

--- a/js/OscillatorNode.js
+++ b/js/OscillatorNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');

--- a/js/OscillatorNode.js
+++ b/js/OscillatorNode.js
@@ -1,15 +1,70 @@
-const EventTargetMixin = require('./EventTarget.mixin.js');
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+//                                                                            //
+//                                                                            //
+//                                                                            //
+//    ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗               //
+//    ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝               //
+//    ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗              //
+//    ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║              //
+//    ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝              //
+//     ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝               //
+//                                                                            //
+//                                                                            //
+//    - This file has been generated ---------------------------              //
+//                                                                            //
+//                                                                            //
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
 
-module.exports = function(NativeOscillatorNode) {
-  class OscillatorNode extends EventTargetMixin(NativeOscillatorNode, ['ended']) {
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
+const AudioScheduledSourceNodeMixin = require('./AudioScheduledSourceNode.mixin.js');
+
+module.exports = (NativeOscillatorNode) => {
+
+  const EventTarget = EventTargetMixin(NativeOscillatorNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+  const AudioScheduledSourceNode = AudioScheduledSourceNodeMixin(AudioNode);
+
+  class OscillatorNode extends AudioScheduledSourceNode {
     constructor(audioContext, options) {
       super(audioContext, options);
       // EventTargetMixin has been called so EventTargetMixin[kDispatchEvent] is
       // bound to this, then we can safely finalize event target initialization
       super.__initEventTarget__();
     }
+
+    // getters
+
+    get type() {
+      return super.type;
+    }
+
+    // setters
+
+    set type(value) {
+      try {
+        super.type = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    // methods
+    
+    setPeriodicWave(...args) {
+      try {
+        return super.setPeriodicWave(...args);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
   }
 
   return OscillatorNode;
-};
+}
 
+
+  

--- a/js/PannerNode.js
+++ b/js/PannerNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,16 @@ module.exports = (NativePannerNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class PannerNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+      this.positionX = new AudioParam(this.positionX);
+      this.positionY = new AudioParam(this.positionY);
+      this.positionZ = new AudioParam(this.positionZ);
+      this.orientationX = new AudioParam(this.orientationX);
+      this.orientationY = new AudioParam(this.orientationY);
+      this.orientationZ = new AudioParam(this.orientationZ);
+    }
 
     // getters
 
@@ -151,7 +162,7 @@ module.exports = (NativePannerNode) => {
   }
 
   return PannerNode;
-}
+};
 
 
   

--- a/js/PannerNode.js
+++ b/js/PannerNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/PannerNode.js
+++ b/js/PannerNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativePannerNode) => {
 
-  const EventTarget = EventTargetMixin(NativePannerNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativePannerNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class PannerNode extends AudioNode {

--- a/js/PannerNode.js
+++ b/js/PannerNode.js
@@ -17,57 +17,112 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativePannerNode) => {
+
+  const EventTarget = EventTargetMixin(NativePannerNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class PannerNode extends AudioNode {
+
     // getters
 
-    get context() {
-      return super.context;
+    get panningModel() {
+      return super.panningModel;
     }
 
-    get numberOfInputs() {
-      return super.numberOfInputs;
+    get distanceModel() {
+      return super.distanceModel;
     }
 
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
+    get refDistance() {
+      return super.refDistance;
     }
 
-    get channelCount() {
-      return super.channelCount;
+    get maxDistance() {
+      return super.maxDistance;
     }
 
-    get channelCountMode() {
-      return super.channelCountMode;
+    get rolloffFactor() {
+      return super.rolloffFactor;
     }
 
-    get channelInterpretation() {
-      return super.channelInterpretation;
+    get coneInnerAngle() {
+      return super.coneInnerAngle;
+    }
+
+    get coneOuterAngle() {
+      return super.coneOuterAngle;
+    }
+
+    get coneOuterGain() {
+      return super.coneOuterGain;
     }
 
     // setters
 
-    set channelCount(value) {
+    set panningModel(value) {
       try {
-        super.channelCount = value;
+        super.panningModel = value;
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    set channelCountMode(value) {
+    set distanceModel(value) {
       try {
-        super.channelCountMode = value;
+        super.distanceModel = value;
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    set channelInterpretation(value) {
+    set refDistance(value) {
       try {
-        super.channelInterpretation = value;
+        super.refDistance = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set maxDistance(value) {
+      try {
+        super.maxDistance = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set rolloffFactor(value) {
+      try {
+        super.rolloffFactor = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set coneInnerAngle(value) {
+      try {
+        super.coneInnerAngle = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set coneOuterAngle(value) {
+      try {
+        super.coneOuterAngle = value;
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+    }
+
+    set coneOuterGain(value) {
+      try {
+        super.coneOuterGain = value;
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -75,17 +130,17 @@ module.exports = (superclass) => {
 
     // methods
     
-    connect(...args) {
+    setPosition(...args) {
       try {
-        return super.connect(...args);
+        return super.setPosition(...args);
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    disconnect(...args) {
+    setOrientation(...args) {
       try {
-        return super.disconnect(...args);
+        return super.setOrientation(...args);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -93,7 +148,8 @@ module.exports = (superclass) => {
 
   }
 
-  return AudioNode;
+  return PannerNode;
 }
+
 
   

--- a/js/StereoPannerNode.js
+++ b/js/StereoPannerNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/StereoPannerNode.js
+++ b/js/StereoPannerNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,11 @@ module.exports = (NativeStereoPannerNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class StereoPannerNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+      this.pan = new AudioParam(this.pan);
+    }
 
     // getters
 
@@ -39,7 +45,7 @@ module.exports = (NativeStereoPannerNode) => {
   }
 
   return StereoPannerNode;
-}
+};
 
 
   

--- a/js/StereoPannerNode.js
+++ b/js/StereoPannerNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeStereoPannerNode) => {
 
-  const EventTarget = EventTargetMixin(NativeStereoPannerNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeStereoPannerNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class StereoPannerNode extends AudioNode {

--- a/js/StereoPannerNode.js
+++ b/js/StereoPannerNode.js
@@ -17,83 +17,27 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeStereoPannerNode) => {
+
+  const EventTarget = EventTargetMixin(NativeStereoPannerNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class StereoPannerNode extends AudioNode {
+
     // getters
-
-    get context() {
-      return super.context;
-    }
-
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
-    }
 
     // setters
 
-    set channelCount(value) {
-      try {
-        super.channelCount = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelCountMode(value) {
-      try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return StereoPannerNode;
 }
+
 
   

--- a/js/WaveShaperNode.js
+++ b/js/WaveShaperNode.js
@@ -17,57 +17,40 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-const { throwSanitizedError } = require('./lib/errors.js');
+const EventTargetMixin = require('./EventTarget.mixin.js');
+const AudioNodeMixin = require('./AudioNode.mixin.js');
 
-module.exports = (superclass) => {
-  class AudioNode extends superclass {
+
+module.exports = (NativeWaveShaperNode) => {
+
+  const EventTarget = EventTargetMixin(NativeWaveShaperNode, ['ended']);
+  const AudioNode = AudioNodeMixin(EventTarget);
+
+  class WaveShaperNode extends AudioNode {
+
     // getters
 
-    get context() {
-      return super.context;
+    get curve() {
+      return super.curve;
     }
 
-    get numberOfInputs() {
-      return super.numberOfInputs;
-    }
-
-    get numberOfOutputs() {
-      return super.numberOfOutputs;
-    }
-
-    get channelCount() {
-      return super.channelCount;
-    }
-
-    get channelCountMode() {
-      return super.channelCountMode;
-    }
-
-    get channelInterpretation() {
-      return super.channelInterpretation;
+    get oversample() {
+      return super.oversample;
     }
 
     // setters
 
-    set channelCount(value) {
+    set curve(value) {
       try {
-        super.channelCount = value;
+        super.curve = value;
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    set channelCountMode(value) {
+    set oversample(value) {
       try {
-        super.channelCountMode = value;
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    set channelInterpretation(value) {
-      try {
-        super.channelInterpretation = value;
+        super.oversample = value;
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -75,25 +58,10 @@ module.exports = (superclass) => {
 
     // methods
     
-    connect(...args) {
-      try {
-        return super.connect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
-    disconnect(...args) {
-      try {
-        return super.disconnect(...args);
-      } catch (err) {
-        throwSanitizedError(err);
-      }
-    }
-
   }
 
-  return AudioNode;
+  return WaveShaperNode;
 }
+
 
   

--- a/js/WaveShaperNode.js
+++ b/js/WaveShaperNode.js
@@ -17,6 +17,8 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const { throwSanitizedError } = require('./lib/errors.js');
+
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 

--- a/js/WaveShaperNode.js
+++ b/js/WaveShaperNode.js
@@ -25,7 +25,7 @@ const AudioNodeMixin = require('./AudioNode.mixin.js');
 
 module.exports = (NativeWaveShaperNode) => {
 
-  const EventTarget = EventTargetMixin(NativeWaveShaperNode, ['ended']);
+  const EventTarget = EventTargetMixin(NativeWaveShaperNode);
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class WaveShaperNode extends AudioNode {

--- a/js/WaveShaperNode.js
+++ b/js/WaveShaperNode.js
@@ -19,6 +19,7 @@
 
 const { throwSanitizedError } = require('./lib/errors.js');
 
+const { AudioParam } = require('./AudioParam.js');
 const EventTargetMixin = require('./EventTarget.mixin.js');
 const AudioNodeMixin = require('./AudioNode.mixin.js');
 
@@ -29,6 +30,10 @@ module.exports = (NativeWaveShaperNode) => {
   const AudioNode = AudioNodeMixin(EventTarget);
 
   class WaveShaperNode extends AudioNode {
+    constructor(context, options) {
+      super(context, options);
+
+    }
 
     // getters
 
@@ -63,7 +68,7 @@ module.exports = (NativeWaveShaperNode) => {
   }
 
   return WaveShaperNode;
-}
+};
 
 
   

--- a/js/lib/errors.js
+++ b/js/lib/errors.js
@@ -1,18 +1,29 @@
 const { EOL } = require('os');
 
-exports.NotSupportedError = class NotSupportedError extends Error {
+class NotSupportedError extends Error {
   constructor(message) {
     super(message);
     this.name = 'NotSupportedError';
   }
 }
 
-exports.InvalidStateError = class InvalidStateError extends Error {
+class InvalidStateError extends Error {
   constructor(message) {
     super(message);
-    this.name = 'RangeError';
+    this.name = 'InvalidStateError';
   }
 }
+
+class IndexSizeError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'IndexSizeError';
+  }
+}
+
+exports.NotSupportedError = NotSupportedError;
+exports.InvalidStateError = InvalidStateError;
+exports.IndexSizeError = IndexSizeError;
 
 function overrideStack(originalError, newError) {
   const lines = originalError.stack.split(EOL);
@@ -27,7 +38,6 @@ function overrideStack(originalError, newError) {
 exports.throwSanitizedError = function throwSanitizedError(err) {
   // "Native Errors"
   if (err.message.startsWith('TypeError')) {
-    console.log('here?')
     const msg = err.message.replace(/^TypeError - /, '');
     const error = new TypeError(msg);
     overrideStack(err, error);
@@ -51,6 +61,12 @@ exports.throwSanitizedError = function throwSanitizedError(err) {
   } else  if (err.message.startsWith('InvalidStateError')) {
     const msg = err.message.replace(/^InvalidStateError - /, '');
     const error = new InvalidStateError(msg);
+    overrideStack(err, error);
+
+    throw error;
+  } if (err.message.startsWith('IndexSizeError')) {
+    const msg = err.message.replace(/^IndexSizeError - /, '');
+    const error = new IndexSizeError(msg);
     overrideStack(err, error);
 
     throw error;

--- a/js/lib/errors.js
+++ b/js/lib/errors.js
@@ -56,29 +56,6 @@ exports.throwSanitizedError = function throwSanitizedError(err) {
     throw error;
   } // etc...
 
-  // not handled yet...
+  console.warn('[lib/errors.js] Unhandled error type', err.name, err.message);
   throw err;
 }
-
-exports.errorHandler = {
-  set(obj, prop, value) {
-    console.log(obj, prop, value);
-    try {
-      return Reflect.set(obj, prop, value);
-    } catch (err) {
-      console.log(err.message);
-      throwSanitizedError(err);
-    }
-    return true;
-  },
-  apply(target, thisArg, argumentsList) {
-    console.log('in apply');
-    try {
-      return Reflect.apply(target, thisArg, argumentsList);
-    } catch (err) {
-      throwSanitizedError(err);
-    }
-    return true;
-  },
-};
-

--- a/js/lib/errors.js
+++ b/js/lib/errors.js
@@ -21,6 +21,13 @@ class IndexSizeError extends Error {
   }
 }
 
+class InvalidAccessError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'InvalidAccessError';
+  }
+}
+
 exports.NotSupportedError = NotSupportedError;
 exports.InvalidStateError = InvalidStateError;
 exports.IndexSizeError = IndexSizeError;
@@ -70,7 +77,13 @@ exports.throwSanitizedError = function throwSanitizedError(err) {
     overrideStack(err, error);
 
     throw error;
-  } // etc...
+  } if (err.message.startsWith('InvalidAccessError')) {
+    const msg = err.message.replace(/^InvalidAccessError - /, '');
+    const error = new InvalidAccessError(msg);
+    overrideStack(err, error);
+
+    throw error;
+  }
 
   console.warn('[lib/errors.js] Unhandled error type', err.name, err.message);
   throw err;

--- a/js/lib/errors.js
+++ b/js/lib/errors.js
@@ -1,8 +1,84 @@
-class NotSupportedError extends Error {
+const { EOL } = require('os');
+
+exports.NotSupportedError = class NotSupportedError extends Error {
   constructor(message) {
     super(message);
     this.name = 'NotSupportedError';
   }
 }
 
-exports.NotSupportedError = NotSupportedError;
+exports.InvalidStateError = class InvalidStateError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'RangeError';
+  }
+}
+
+function overrideStack(originalError, newError) {
+  const lines = originalError.stack.split(EOL);
+  // override previous error message
+  lines[0] = newError.message;
+  // remove first stack line which correspond to the try / catch in Object
+  lines.splice(1, 1);
+  // override new stack with modified one
+  newError.stack = lines.join(EOL);
+}
+
+exports.throwSanitizedError = function throwSanitizedError(err) {
+  // "Native Errors"
+  if (err.message.startsWith('TypeError')) {
+    console.log('here?')
+    const msg = err.message.replace(/^TypeError - /, '');
+    const error = new TypeError(msg);
+    overrideStack(err, error);
+
+    throw error;
+  } else if (err.message.startsWith('RangeError')) {
+    const msg = err.message.replace(/^RangeError - /, '');
+    const error = new RangeError(msg);
+    overrideStack(err, error);
+
+    throw error;
+  }
+
+  // "other errors"
+  if (err.message.startsWith('NotSupportedError')) {
+    const msg = err.message.replace(/^NotSupportedError - /, '');
+    const error = new NotSupportedError(msg);
+    overrideStack(err, error);
+
+    throw error;
+  } else  if (err.message.startsWith('InvalidStateError')) {
+    const msg = err.message.replace(/^InvalidStateError - /, '');
+    const error = new InvalidStateError(msg);
+    overrideStack(err, error);
+
+    throw error;
+  } // etc...
+
+  // not handled yet...
+  throw err;
+}
+
+exports.errorHandler = {
+  set(obj, prop, value) {
+    console.log(obj, prop, value);
+    try {
+      return Reflect.set(obj, prop, value);
+    } catch (err) {
+      console.log(err.message);
+      throwSanitizedError(err);
+    }
+    return true;
+  },
+  apply(target, thisArg, argumentsList) {
+    console.log('in apply');
+    try {
+      return Reflect.apply(target, thisArg, argumentsList);
+    } catch (err) {
+      throwSanitizedError(err);
+    }
+    return true;
+  },
+};
+

--- a/js/monkey-patch.js
+++ b/js/monkey-patch.js
@@ -1,0 +1,67 @@
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+//                                                                            //
+//                                                                            //
+//                                                                            //
+//    ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗               //
+//    ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝               //
+//    ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗              //
+//    ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║              //
+//    ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝              //
+//     ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝               //
+//                                                                            //
+//                                                                            //
+//    - This file has been generated ---------------------------              //
+//                                                                            //
+//                                                                            //
+// -------------------------------------------------------------------------- //
+// -------------------------------------------------------------------------- //
+
+module.exports = function monkeyPatch(nativeBinding) {
+  // --------------------------------------------------------------------------
+  // Monkey Patch Web Audio API
+  // --------------------------------------------------------------------------
+
+  nativeBinding.AnalyserNode = require('./AnalyserNode.js')(nativeBinding.AnalyserNode);
+  nativeBinding.AudioBufferSourceNode = require('./AudioBufferSourceNode.js')(nativeBinding.AudioBufferSourceNode);
+  nativeBinding.BiquadFilterNode = require('./BiquadFilterNode.js')(nativeBinding.BiquadFilterNode);
+  nativeBinding.ChannelMergerNode = require('./ChannelMergerNode.js')(nativeBinding.ChannelMergerNode);
+  nativeBinding.ChannelSplitterNode = require('./ChannelSplitterNode.js')(nativeBinding.ChannelSplitterNode);
+  nativeBinding.ConstantSourceNode = require('./ConstantSourceNode.js')(nativeBinding.ConstantSourceNode);
+  nativeBinding.ConvolverNode = require('./ConvolverNode.js')(nativeBinding.ConvolverNode);
+  nativeBinding.DelayNode = require('./DelayNode.js')(nativeBinding.DelayNode);
+  nativeBinding.DynamicsCompressorNode = require('./DynamicsCompressorNode.js')(nativeBinding.DynamicsCompressorNode);
+  nativeBinding.GainNode = require('./GainNode.js')(nativeBinding.GainNode);
+  nativeBinding.IIRFilterNode = require('./IIRFilterNode.js')(nativeBinding.IIRFilterNode);
+  nativeBinding.OscillatorNode = require('./OscillatorNode.js')(nativeBinding.OscillatorNode);
+  nativeBinding.PannerNode = require('./PannerNode.js')(nativeBinding.PannerNode);
+  nativeBinding.StereoPannerNode = require('./StereoPannerNode.js')(nativeBinding.StereoPannerNode);
+  nativeBinding.WaveShaperNode = require('./WaveShaperNode.js')(nativeBinding.WaveShaperNode);
+
+  nativeBinding.AudioContext = require('./AudioContext.js')(nativeBinding);
+  nativeBinding.OfflineAudioContext = require('./OfflineAudioContext.js')(nativeBinding);
+
+  // --------------------------------------------------------------------------
+  // Promisify MediaDevices API
+  // --------------------------------------------------------------------------
+  const enumerateDevicesSync = nativeBinding.mediaDevices.enumerateDevices;
+  nativeBinding.mediaDevices.enumerateDevices = async function enumerateDevices() {
+    const list = enumerateDevicesSync();
+    return Promise.resolve(list);
+  };
+
+  const getUserMediaSync = nativeBinding.mediaDevices.getUserMedia;
+  nativeBinding.mediaDevices.getUserMedia = async function getUserMedia(options) {
+    if (options === undefined) {
+      throw new TypeError('Failed to execute "getUserMedia" on "MediaDevices": audio must be requested');
+    }
+
+    const stream = getUserMediaSync(options);
+    return Promise.resolve(stream);
+  };
+
+  return nativeBinding;
+};
+
+
+  

--- a/src/analyser_node.rs
+++ b/src/analyser_node.rs
@@ -103,7 +103,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg = "Failed to construct 'AnalyserNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'AnalyserNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -117,7 +117,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'AnalyserNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'AnalyserNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -127,7 +127,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'AnalyserNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'AnalyserNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -145,32 +145,34 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let options = if let Ok(either_options) = ctx.try_get::<JsObject>(1) {
         match either_options {
             Either::A(options_js) => {
-                let some_fft_size_js = options_js.get::<&str, JsNumber>("fftSize")?;
+                let some_fft_size_js = options_js.get::<&str, JsObject>("fftSize")?;
                 let fft_size = if let Some(fft_size_js) = some_fft_size_js {
-                    fft_size_js.get_double()? as usize
+                    fft_size_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     2048
                 };
 
-                let some_max_decibels_js = options_js.get::<&str, JsNumber>("maxDecibels")?;
+                let some_max_decibels_js = options_js.get::<&str, JsObject>("maxDecibels")?;
                 let max_decibels = if let Some(max_decibels_js) = some_max_decibels_js {
-                    max_decibels_js.get_double()?
+                    max_decibels_js.coerce_to_number()?.get_double()?
                 } else {
                     -30.
                 };
 
-                let some_min_decibels_js = options_js.get::<&str, JsNumber>("minDecibels")?;
+                let some_min_decibels_js = options_js.get::<&str, JsObject>("minDecibels")?;
                 let min_decibels = if let Some(min_decibels_js) = some_min_decibels_js {
-                    min_decibels_js.get_double()?
+                    min_decibels_js.coerce_to_number()?.get_double()?
                 } else {
                     -100.
                 };
 
                 let some_smoothing_time_constant_js =
-                    options_js.get::<&str, JsNumber>("smoothingTimeConstant")?;
+                    options_js.get::<&str, JsObject>("smoothingTimeConstant")?;
                 let smoothing_time_constant =
                     if let Some(smoothing_time_constant_js) = some_smoothing_time_constant_js {
-                        smoothing_time_constant_js.get_double()?
+                        smoothing_time_constant_js
+                            .coerce_to_number()?
+                            .get_double()?
                     } else {
                         0.8
                     };
@@ -178,36 +180,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = AnalyserOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,
@@ -451,7 +457,7 @@ fn set_fft_size(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiAnalyserNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as usize;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as usize;
     node.set_fft_size(value);
 
     ctx.env.get_undefined()
@@ -463,7 +469,7 @@ fn set_min_decibels(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiAnalyserNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_min_decibels(value);
 
     ctx.env.get_undefined()
@@ -475,7 +481,7 @@ fn set_max_decibels(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiAnalyserNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_max_decibels(value);
 
     ctx.env.get_undefined()
@@ -487,7 +493,7 @@ fn set_smoothing_time_constant(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiAnalyserNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_smoothing_time_constant(value);
 
     ctx.env.get_undefined()

--- a/src/analyser_node.rs
+++ b/src/analyser_node.rs
@@ -109,10 +109,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/analyser_node.rs
+++ b/src/analyser_node.rs
@@ -190,40 +190,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 AnalyserOptions {
                     fft_size,
@@ -322,7 +324,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -355,7 +357,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/analyser_node.rs
+++ b/src/analyser_node.rs
@@ -111,23 +111,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'AnalyserNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'AnalyserNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'AnalyserNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -105,23 +105,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'AudioBufferSourceNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'AudioBufferSourceNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'AudioBufferSourceNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -103,10 +103,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -291,7 +291,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -324,7 +324,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -97,8 +97,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg =
-            "Failed to construct 'AudioBufferSourceNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'AudioBufferSourceNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -112,7 +111,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'AudioBufferSourceNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'AudioBufferSourceNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -122,7 +121,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'AudioBufferSourceNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'AudioBufferSourceNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -148,37 +147,37 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                     None
                 };
 
-                let some_detune_js = options_js.get::<&str, JsNumber>("detune")?;
+                let some_detune_js = options_js.get::<&str, JsObject>("detune")?;
                 let detune = if let Some(detune_js) = some_detune_js {
-                    detune_js.get_double()? as f32
+                    detune_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
 
-                let some_loop_js = options_js.get::<&str, JsBoolean>("loop")?;
+                let some_loop_js = options_js.get::<&str, JsObject>("loop")?;
                 let loop_ = if let Some(loop_js) = some_loop_js {
-                    loop_js.try_into()?
+                    loop_js.coerce_to_bool()?.try_into()?
                 } else {
                     false
                 };
 
-                let some_loop_end_js = options_js.get::<&str, JsNumber>("loopEnd")?;
+                let some_loop_end_js = options_js.get::<&str, JsObject>("loopEnd")?;
                 let loop_end = if let Some(loop_end_js) = some_loop_end_js {
-                    loop_end_js.get_double()?
+                    loop_end_js.coerce_to_number()?.get_double()?
                 } else {
                     0.
                 };
 
-                let some_loop_start_js = options_js.get::<&str, JsNumber>("loopStart")?;
+                let some_loop_start_js = options_js.get::<&str, JsObject>("loopStart")?;
                 let loop_start = if let Some(loop_start_js) = some_loop_start_js {
-                    loop_start_js.get_double()?
+                    loop_start_js.coerce_to_number()?.get_double()?
                 } else {
                     0.
                 };
 
-                let some_playback_rate_js = options_js.get::<&str, JsNumber>("playbackRate")?;
+                let some_playback_rate_js = options_js.get::<&str, JsObject>("playbackRate")?;
                 let playback_rate = if let Some(playback_rate_js) = some_playback_rate_js {
-                    playback_rate_js.get_double()? as f32
+                    playback_rate_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     1.
                 };
@@ -372,18 +371,18 @@ fn start(ctx: CallContext) -> Result<JsUndefined> {
     match ctx.length {
         0 => node.start(),
         1 => {
-            let when = ctx.get::<JsNumber>(0)?.get_double()?;
+            let when = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
             node.start_at(when);
         }
         2 => {
-            let when = ctx.get::<JsNumber>(0)?.get_double()?;
-            let offset = ctx.get::<JsNumber>(1)?.get_double()?;
+            let when = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
+            let offset = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
             node.start_at_with_offset(when, offset);
         }
         3 => {
-            let when = ctx.get::<JsNumber>(0)?.get_double()?;
-            let offset = ctx.get::<JsNumber>(1)?.get_double()?;
-            let duration = ctx.get::<JsNumber>(2)?.get_double()?;
+            let when = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
+            let offset = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
+            let duration = ctx.get::<JsObject>(2)?.coerce_to_number()?.get_double()?;
             node.start_at_with_offset_and_duration(when, offset, duration);
         }
         _ => (),
@@ -401,7 +400,7 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
     match ctx.length {
         0 => node.stop(),
         1 => {
-            let when = ctx.get::<JsNumber>(0)?.try_into()?;
+            let when = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
             node.stop_at(when);
         }
         _ => (),
@@ -545,7 +544,7 @@ fn set_loop(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiAudioBufferSourceNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsBoolean>(0)?.try_into()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_bool()?.try_into()?;
     node.set_loop(value);
 
     ctx.env.get_undefined()
@@ -557,7 +556,7 @@ fn set_loop_start(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiAudioBufferSourceNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_loop_start(value);
 
     ctx.env.get_undefined()
@@ -569,7 +568,7 @@ fn set_loop_end(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiAudioBufferSourceNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_loop_end(value);
 
     ctx.env.get_undefined()

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -70,6 +70,7 @@ impl NapiAudioContext {
                 // ----------------------------------------------------
                 Property::new("baseLatency")?.with_getter(get_base_latency),
                 Property::new("outputLatency")?.with_getter(get_output_latency),
+                Property::new("sinkId")?.with_getter(get_sink_id),
                 Property::new("setSinkId")?.with_method(set_sink_id),
                 // implementation specific to online audio context
                 Property::new("resume")?.with_method(resume),
@@ -410,6 +411,16 @@ fn get_output_latency(ctx: CallContext) -> Result<JsNumber> {
 
     let output_latency = obj.output_latency();
     ctx.env.create_double(output_latency)
+}
+
+#[js_function]
+fn get_sink_id(ctx: CallContext) -> Result<JsString> {
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_obj = ctx.env.unwrap::<NapiAudioContext>(&js_this)?;
+    let obj = napi_obj.unwrap();
+
+    let sink_id = obj.sink_id();
+    ctx.env.create_string(&sink_id)
 }
 
 #[js_function(1)]

--- a/src/audio_param.rs
+++ b/src/audio_param.rs
@@ -84,10 +84,10 @@ fn get_automation_rate(ctx: CallContext) -> Result<JsString> {
 fn set_automation_rate(ctx: CallContext) -> Result<JsUndefined> {
     let js_this = ctx.this_unchecked::<JsObject>();
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
-    let obj = napi_obj.unwrap();
+    let obj = &mut napi_obj.0;
 
-    let js_str = ctx.get::<JsString>(0)?;
-    let utf8_str = js_str.into_utf8()?.into_owned()?;
+    let js_str = ctx.get::<JsObject>(0)?;
+    let utf8_str = js_str.coerce_to_string()?.into_utf8()?.into_owned()?;
     let value = match utf8_str.as_str() {
         "a-rate" => AutomationRate::A,
         "k-rate" => AutomationRate::K,
@@ -147,7 +147,7 @@ fn set_value(ctx: CallContext) -> Result<JsUndefined> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
     obj.set_value(value);
 
     ctx.env.get_undefined()
@@ -160,8 +160,8 @@ fn set_value_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
-    let start_time = ctx.get::<JsNumber>(1)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
+    let start_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
     obj.set_value_at_time(value as f32, start_time);
 
     Ok(js_this)
@@ -173,8 +173,8 @@ fn linear_ramp_to_value_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
-    let end_time = ctx.get::<JsNumber>(1)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
+    let end_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
     obj.linear_ramp_to_value_at_time(value, end_time);
 
     Ok(js_this)
@@ -186,8 +186,8 @@ fn exponential_ramp_to_value_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
-    let end_time = ctx.get::<JsNumber>(1)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
+    let end_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
     obj.exponential_ramp_to_value_at_time(value, end_time);
 
     Ok(js_this)
@@ -202,8 +202,8 @@ fn set_value_curve_at_time(ctx: CallContext) -> Result<JsObject> {
     let mut typed_array_values = ctx.get::<JsTypedArray>(0)?.into_value()?;
     let values: &mut [f32] = typed_array_values.as_mut();
 
-    let start_time = ctx.get::<JsNumber>(1)?.get_double()?;
-    let duration = ctx.get::<JsNumber>(2)?.get_double()?;
+    let start_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
+    let duration = ctx.get::<JsObject>(2)?.coerce_to_number()?.get_double()?;
     obj.set_value_curve_at_time(values, start_time, duration);
 
     Ok(js_this)
@@ -215,9 +215,9 @@ fn set_target_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()? as f32;
-    let start_time = ctx.get::<JsNumber>(1)?.get_double()?;
-    let time_constant = ctx.get::<JsNumber>(2)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as f32;
+    let start_time = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()?;
+    let time_constant = ctx.get::<JsObject>(2)?.coerce_to_number()?.get_double()?;
     obj.set_target_at_time(value, start_time, time_constant);
 
     Ok(js_this)
@@ -229,7 +229,7 @@ fn cancel_scheduled_values(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let cancel_time = ctx.get::<JsNumber>(0)?.get_double()?;
+    let cancel_time = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     obj.cancel_scheduled_values(cancel_time);
 
     Ok(js_this)
@@ -241,7 +241,7 @@ fn cancel_and_hold_at_time(ctx: CallContext) -> Result<JsObject> {
     let napi_obj = ctx.env.unwrap::<NapiAudioParam>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let cancel_time = ctx.get::<JsNumber>(0)?.get_double()?;
+    let cancel_time = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     obj.cancel_and_hold_at_time(cancel_time);
 
     Ok(js_this)

--- a/src/biquad_filter_node.rs
+++ b/src/biquad_filter_node.rs
@@ -79,8 +79,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg =
-            "Failed to construct 'BiquadFilterNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'BiquadFilterNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -94,7 +93,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'BiquadFilterNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'BiquadFilterNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -104,7 +103,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'BiquadFilterNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'BiquadFilterNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -141,30 +140,30 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                     BiquadFilterType::default()
                 };
 
-                let some_q_js = options_js.get::<&str, JsNumber>("Q")?;
+                let some_q_js = options_js.get::<&str, JsObject>("Q")?;
                 let q = if let Some(q_js) = some_q_js {
-                    q_js.get_double()? as f32
+                    q_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     1.
                 };
 
-                let some_detune_js = options_js.get::<&str, JsNumber>("detune")?;
+                let some_detune_js = options_js.get::<&str, JsObject>("detune")?;
                 let detune = if let Some(detune_js) = some_detune_js {
-                    detune_js.get_double()? as f32
+                    detune_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
 
-                let some_frequency_js = options_js.get::<&str, JsNumber>("frequency")?;
+                let some_frequency_js = options_js.get::<&str, JsObject>("frequency")?;
                 let frequency = if let Some(frequency_js) = some_frequency_js {
-                    frequency_js.get_double()? as f32
+                    frequency_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     350.
                 };
 
-                let some_gain_js = options_js.get::<&str, JsNumber>("gain")?;
+                let some_gain_js = options_js.get::<&str, JsObject>("gain")?;
                 let gain = if let Some(gain_js) = some_gain_js {
-                    gain_js.get_double()? as f32
+                    gain_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
@@ -172,36 +171,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = BiquadFilterOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,
@@ -445,7 +448,7 @@ fn set_type(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiBiquadFilterNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let js_str = ctx.get::<JsString>(0)?;
+    let js_str = ctx.get::<JsObject>(0)?.coerce_to_string()?;
     let utf8_str = js_str.into_utf8()?.into_owned()?;
     let value = match utf8_str.as_str() {
         "lowpass" => BiquadFilterType::Lowpass,

--- a/src/biquad_filter_node.rs
+++ b/src/biquad_filter_node.rs
@@ -85,10 +85,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/biquad_filter_node.rs
+++ b/src/biquad_filter_node.rs
@@ -181,40 +181,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 BiquadFilterOptions {
                     type_,
@@ -342,7 +344,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -375,7 +377,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/biquad_filter_node.rs
+++ b/src/biquad_filter_node.rs
@@ -87,23 +87,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'BiquadFilterNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'BiquadFilterNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'BiquadFilterNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/channel_merger_node.rs
+++ b/src/channel_merger_node.rs
@@ -137,40 +137,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 ChannelMergerOptions {
                     number_of_inputs,
@@ -266,7 +268,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -299,7 +301,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/channel_merger_node.rs
+++ b/src/channel_merger_node.rs
@@ -80,10 +80,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/channel_merger_node.rs
+++ b/src/channel_merger_node.rs
@@ -74,8 +74,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg =
-            "Failed to construct 'ChannelMergerNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'ChannelMergerNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -89,7 +88,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'ChannelMergerNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'ChannelMergerNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -99,7 +98,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'ChannelMergerNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'ChannelMergerNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -118,9 +117,9 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         match either_options {
             Either::A(options_js) => {
                 let some_number_of_inputs_js =
-                    options_js.get::<&str, JsNumber>("numberOfInputs")?;
+                    options_js.get::<&str, JsObject>("numberOfInputs")?;
                 let number_of_inputs = if let Some(number_of_inputs_js) = some_number_of_inputs_js {
-                    number_of_inputs_js.get_double()? as usize
+                    number_of_inputs_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     6
                 };
@@ -128,36 +127,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = ChannelMergerOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,

--- a/src/channel_merger_node.rs
+++ b/src/channel_merger_node.rs
@@ -82,23 +82,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'ChannelMergerNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'ChannelMergerNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'ChannelMergerNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/channel_splitter_node.rs
+++ b/src/channel_splitter_node.rs
@@ -80,10 +80,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/channel_splitter_node.rs
+++ b/src/channel_splitter_node.rs
@@ -74,8 +74,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg =
-            "Failed to construct 'ChannelSplitterNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'ChannelSplitterNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -89,7 +88,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'ChannelSplitterNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'ChannelSplitterNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -99,7 +98,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'ChannelSplitterNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'ChannelSplitterNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -118,10 +117,10 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         match either_options {
             Either::A(options_js) => {
                 let some_number_of_outputs_js =
-                    options_js.get::<&str, JsNumber>("numberOfOutputs")?;
+                    options_js.get::<&str, JsObject>("numberOfOutputs")?;
                 let number_of_outputs =
                     if let Some(number_of_outputs_js) = some_number_of_outputs_js {
-                        number_of_outputs_js.get_double()? as usize
+                        number_of_outputs_js.coerce_to_number()?.get_double()? as usize
                     } else {
                         6
                     };
@@ -129,36 +128,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = ChannelSplitterOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,

--- a/src/channel_splitter_node.rs
+++ b/src/channel_splitter_node.rs
@@ -82,23 +82,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'ChannelSplitterNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'ChannelSplitterNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'ChannelSplitterNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/channel_splitter_node.rs
+++ b/src/channel_splitter_node.rs
@@ -138,40 +138,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 ChannelSplitterOptions {
                     number_of_outputs,
@@ -267,7 +269,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -300,7 +302,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/constant_source_node.rs
+++ b/src/constant_source_node.rs
@@ -226,7 +226,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -259,7 +259,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/constant_source_node.rs
+++ b/src/constant_source_node.rs
@@ -88,10 +88,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/constant_source_node.rs
+++ b/src/constant_source_node.rs
@@ -82,8 +82,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg =
-            "Failed to construct 'ConstantSourceNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'ConstantSourceNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -97,7 +96,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'ConstantSourceNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'ConstantSourceNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -107,7 +106,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'ConstantSourceNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'ConstantSourceNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -125,9 +124,9 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let options = if let Ok(either_options) = ctx.try_get::<JsObject>(1) {
         match either_options {
             Either::A(options_js) => {
-                let some_offset_js = options_js.get::<&str, JsNumber>("offset")?;
+                let some_offset_js = options_js.get::<&str, JsObject>("offset")?;
                 let offset = if let Some(offset_js) = some_offset_js {
-                    offset_js.get_double()? as f32
+                    offset_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     1.
                 };
@@ -307,7 +306,7 @@ fn start(ctx: CallContext) -> Result<JsUndefined> {
     match ctx.length {
         0 => node.start(),
         1 => {
-            let when = ctx.get::<JsNumber>(0)?.get_double()?;
+            let when = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
             node.start_at(when);
         }
         _ => (),
@@ -325,7 +324,7 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
     match ctx.length {
         0 => node.stop(),
         1 => {
-            let when = ctx.get::<JsNumber>(0)?.try_into()?;
+            let when = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
             node.stop_at(when);
         }
         _ => (),

--- a/src/convolver_node.rs
+++ b/src/convolver_node.rs
@@ -81,7 +81,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg = "Failed to construct 'ConvolverNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'ConvolverNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -95,7 +95,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'ConvolverNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'ConvolverNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -105,7 +105,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'ConvolverNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'ConvolverNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -132,10 +132,10 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 };
 
                 let some_disable_normalization_js =
-                    options_js.get::<&str, JsBoolean>("disableNormalization")?;
+                    options_js.get::<&str, JsObject>("disableNormalization")?;
                 let disable_normalization =
                     if let Some(disable_normalization_js) = some_disable_normalization_js {
-                        disable_normalization_js.try_into()?
+                        disable_normalization_js.coerce_to_bool()?.try_into()?
                     } else {
                         false
                     };
@@ -143,36 +143,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = ConvolverOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,
@@ -403,7 +407,7 @@ fn set_normalize(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiConvolverNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsBoolean>(0)?.try_into()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_bool()?.try_into()?;
     node.set_normalize(value);
 
     ctx.env.get_undefined()

--- a/src/convolver_node.rs
+++ b/src/convolver_node.rs
@@ -89,23 +89,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'ConvolverNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'ConvolverNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'ConvolverNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/convolver_node.rs
+++ b/src/convolver_node.rs
@@ -153,40 +153,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 ConvolverOptions {
                     buffer,
@@ -283,7 +285,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -316,7 +318,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/convolver_node.rs
+++ b/src/convolver_node.rs
@@ -87,10 +87,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/delay_node.rs
+++ b/src/delay_node.rs
@@ -81,10 +81,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/delay_node.rs
+++ b/src/delay_node.rs
@@ -144,40 +144,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 DelayOptions {
                     max_delay_time,
@@ -281,7 +283,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -314,7 +316,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/delay_node.rs
+++ b/src/delay_node.rs
@@ -74,7 +74,8 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg = "Failed to construct 'DelayNode': 1 argument required, but only 0 present.";
+        let msg =
+            "TypeError - Failed to construct 'DelayNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -88,7 +89,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'DelayNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'DelayNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -98,8 +99,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg =
-            "Failed to construct 'DelayNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'DelayNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -117,16 +117,16 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let options = if let Ok(either_options) = ctx.try_get::<JsObject>(1) {
         match either_options {
             Either::A(options_js) => {
-                let some_max_delay_time_js = options_js.get::<&str, JsNumber>("maxDelayTime")?;
+                let some_max_delay_time_js = options_js.get::<&str, JsObject>("maxDelayTime")?;
                 let max_delay_time = if let Some(max_delay_time_js) = some_max_delay_time_js {
-                    max_delay_time_js.get_double()?
+                    max_delay_time_js.coerce_to_number()?.get_double()?
                 } else {
                     1.
                 };
 
-                let some_delay_time_js = options_js.get::<&str, JsNumber>("delayTime")?;
+                let some_delay_time_js = options_js.get::<&str, JsObject>("delayTime")?;
                 let delay_time = if let Some(delay_time_js) = some_delay_time_js {
-                    delay_time_js.get_double()?
+                    delay_time_js.coerce_to_number()?.get_double()?
                 } else {
                     0.
                 };
@@ -134,36 +134,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = DelayOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,

--- a/src/delay_node.rs
+++ b/src/delay_node.rs
@@ -83,23 +83,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'DelayNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'DelayNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'DelayNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/dynamics_compressor_node.rs
+++ b/src/dynamics_compressor_node.rs
@@ -84,23 +84,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'DynamicsCompressorNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'DynamicsCompressorNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'DynamicsCompressorNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/dynamics_compressor_node.rs
+++ b/src/dynamics_compressor_node.rs
@@ -166,40 +166,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 DynamicsCompressorOptions {
                     attack,
@@ -334,7 +336,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -367,7 +369,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/dynamics_compressor_node.rs
+++ b/src/dynamics_compressor_node.rs
@@ -82,10 +82,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -81,10 +81,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -74,7 +74,8 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg = "Failed to construct 'GainNode': 1 argument required, but only 0 present.";
+        let msg =
+            "TypeError - Failed to construct 'GainNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -88,7 +89,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'GainNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'GainNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -98,8 +99,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg =
-            "Failed to construct 'GainNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'GainNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -117,9 +117,9 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let options = if let Ok(either_options) = ctx.try_get::<JsObject>(1) {
         match either_options {
             Either::A(options_js) => {
-                let some_gain_js = options_js.get::<&str, JsNumber>("gain")?;
+                let some_gain_js = options_js.get::<&str, JsObject>("gain")?;
                 let gain = if let Some(gain_js) = some_gain_js {
-                    gain_js.get_double()? as f32
+                    gain_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     1.
                 };
@@ -127,36 +127,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = GainOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -137,40 +137,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 GainOptions {
                     gain,
@@ -273,7 +275,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -306,7 +308,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -83,23 +83,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'GainNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'GainNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'GainNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/iir_filter_node.rs
+++ b/src/iir_filter_node.rs
@@ -156,40 +156,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 IIRFilterOptions {
                     feedforward,
@@ -203,13 +205,13 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
             }
             Either::B(_) => {
                 return Err(napi::Error::from_reason(
-                    "Options are mandatory for node IIRFilterNode".to_string(),
+                    "TypeError - Options are mandatory for node IIRFilterNode".to_string(),
                 ));
             }
         }
     } else {
         return Err(napi::Error::from_reason(
-            "Options are mandatory for node IIRFilterNode".to_string(),
+            "TypeError - Options are mandatory for node IIRFilterNode".to_string(),
         ));
     };
 
@@ -292,7 +294,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -325,7 +327,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/iir_filter_node.rs
+++ b/src/iir_filter_node.rs
@@ -76,7 +76,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg = "Failed to construct 'IIRFilterNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'IIRFilterNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -90,7 +90,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'IIRFilterNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'IIRFilterNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -100,7 +100,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'IIRFilterNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'IIRFilterNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -146,36 +146,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 // can't create default from IIRFilterOptions
                 let channel_config_defaults = ChannelConfigOptions::default();
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,

--- a/src/iir_filter_node.rs
+++ b/src/iir_filter_node.rs
@@ -84,23 +84,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'IIRFilterNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'IIRFilterNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'IIRFilterNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/iir_filter_node.rs
+++ b/src/iir_filter_node.rs
@@ -82,10 +82,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,19 +98,8 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[module_exports]
 fn init(mut exports: JsObject, env: Env) -> Result<()> {
-    // @todo - catch all panics and throw clean JS Error
-    // do not uncomment until it is clean as it swallow the error message and
-    // makes things event more complicated...
-    //
-    // std::panic::set_hook(Box::new(|panic_info| {
-    //     println!("{:?}", panic_info.payload());
-
-    //     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-    //         println!("panic occurred: {s:?}");
-    //     } else {
-    //         println!("panic occurred");
-    //     }
-    // }));
+    // Do not print panic messages, handle through JS errors
+    std::panic::set_hook(Box::new(|_panic_info| {}));
 
     // Store constructors for factory methods and internal instantiations
     // Note that we need to create the js class twice so that export and store

--- a/src/offline_audio_context.rs
+++ b/src/offline_audio_context.rs
@@ -120,9 +120,9 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     // -------------------------------------------------
     // Parse options and create OfflineAudioContext
     // -------------------------------------------------
-    let number_of_channels = ctx.get::<JsNumber>(0)?.get_double()? as usize;
-    let length = ctx.get::<JsNumber>(1)?.get_double()? as usize;
-    let sample_rate = ctx.get::<JsNumber>(2)?.get_double()? as f32;
+    let number_of_channels = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()? as usize;
+    let length = ctx.get::<JsObject>(1)?.coerce_to_number()?.get_double()? as usize;
+    let sample_rate = ctx.get::<JsObject>(2)?.coerce_to_number()?.get_double()? as f32;
 
     let audio_context = OfflineAudioContext::new(number_of_channels, length, sample_rate);
 

--- a/src/oscillator_node.rs
+++ b/src/oscillator_node.rs
@@ -181,40 +181,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 OscillatorOptions {
                     type_,
@@ -327,7 +329,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -360,7 +362,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/oscillator_node.rs
+++ b/src/oscillator_node.rs
@@ -93,10 +93,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/oscillator_node.rs
+++ b/src/oscillator_node.rs
@@ -95,23 +95,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'OscillatorNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'OscillatorNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'OscillatorNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/panner_node.rs
+++ b/src/panner_node.rs
@@ -116,10 +116,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/panner_node.rs
+++ b/src/panner_node.rs
@@ -278,40 +278,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 PannerOptions {
                     panning_model,
@@ -462,7 +464,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -495,7 +497,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/panner_node.rs
+++ b/src/panner_node.rs
@@ -118,23 +118,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'PannerNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'PannerNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'PannerNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/panner_node.rs
+++ b/src/panner_node.rs
@@ -110,7 +110,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg = "Failed to construct 'PannerNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'PannerNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -124,7 +124,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'PannerNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'PannerNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -134,7 +134,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'PannerNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'PannerNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -179,88 +179,88 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                     DistanceModelType::default()
                 };
 
-                let some_position_x_js = options_js.get::<&str, JsNumber>("positionX")?;
+                let some_position_x_js = options_js.get::<&str, JsObject>("positionX")?;
                 let position_x = if let Some(position_x_js) = some_position_x_js {
-                    position_x_js.get_double()? as f32
+                    position_x_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
 
-                let some_position_y_js = options_js.get::<&str, JsNumber>("positionY")?;
+                let some_position_y_js = options_js.get::<&str, JsObject>("positionY")?;
                 let position_y = if let Some(position_y_js) = some_position_y_js {
-                    position_y_js.get_double()? as f32
+                    position_y_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
 
-                let some_position_z_js = options_js.get::<&str, JsNumber>("positionZ")?;
+                let some_position_z_js = options_js.get::<&str, JsObject>("positionZ")?;
                 let position_z = if let Some(position_z_js) = some_position_z_js {
-                    position_z_js.get_double()? as f32
+                    position_z_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
 
-                let some_orientation_x_js = options_js.get::<&str, JsNumber>("orientationX")?;
+                let some_orientation_x_js = options_js.get::<&str, JsObject>("orientationX")?;
                 let orientation_x = if let Some(orientation_x_js) = some_orientation_x_js {
-                    orientation_x_js.get_double()? as f32
+                    orientation_x_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     1.
                 };
 
-                let some_orientation_y_js = options_js.get::<&str, JsNumber>("orientationY")?;
+                let some_orientation_y_js = options_js.get::<&str, JsObject>("orientationY")?;
                 let orientation_y = if let Some(orientation_y_js) = some_orientation_y_js {
-                    orientation_y_js.get_double()? as f32
+                    orientation_y_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
 
-                let some_orientation_z_js = options_js.get::<&str, JsNumber>("orientationZ")?;
+                let some_orientation_z_js = options_js.get::<&str, JsObject>("orientationZ")?;
                 let orientation_z = if let Some(orientation_z_js) = some_orientation_z_js {
-                    orientation_z_js.get_double()? as f32
+                    orientation_z_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
 
-                let some_ref_distance_js = options_js.get::<&str, JsNumber>("refDistance")?;
+                let some_ref_distance_js = options_js.get::<&str, JsObject>("refDistance")?;
                 let ref_distance = if let Some(ref_distance_js) = some_ref_distance_js {
-                    ref_distance_js.get_double()?
+                    ref_distance_js.coerce_to_number()?.get_double()?
                 } else {
                     1.
                 };
 
-                let some_max_distance_js = options_js.get::<&str, JsNumber>("maxDistance")?;
+                let some_max_distance_js = options_js.get::<&str, JsObject>("maxDistance")?;
                 let max_distance = if let Some(max_distance_js) = some_max_distance_js {
-                    max_distance_js.get_double()?
+                    max_distance_js.coerce_to_number()?.get_double()?
                 } else {
                     10000.
                 };
 
-                let some_rolloff_factor_js = options_js.get::<&str, JsNumber>("rolloffFactor")?;
+                let some_rolloff_factor_js = options_js.get::<&str, JsObject>("rolloffFactor")?;
                 let rolloff_factor = if let Some(rolloff_factor_js) = some_rolloff_factor_js {
-                    rolloff_factor_js.get_double()?
+                    rolloff_factor_js.coerce_to_number()?.get_double()?
                 } else {
                     1.
                 };
 
                 let some_cone_inner_angle_js =
-                    options_js.get::<&str, JsNumber>("coneInnerAngle")?;
+                    options_js.get::<&str, JsObject>("coneInnerAngle")?;
                 let cone_inner_angle = if let Some(cone_inner_angle_js) = some_cone_inner_angle_js {
-                    cone_inner_angle_js.get_double()?
+                    cone_inner_angle_js.coerce_to_number()?.get_double()?
                 } else {
                     360.
                 };
 
                 let some_cone_outer_angle_js =
-                    options_js.get::<&str, JsNumber>("coneOuterAngle")?;
+                    options_js.get::<&str, JsObject>("coneOuterAngle")?;
                 let cone_outer_angle = if let Some(cone_outer_angle_js) = some_cone_outer_angle_js {
-                    cone_outer_angle_js.get_double()?
+                    cone_outer_angle_js.coerce_to_number()?.get_double()?
                 } else {
                     360.
                 };
 
-                let some_cone_outer_gain_js = options_js.get::<&str, JsNumber>("coneOuterGain")?;
+                let some_cone_outer_gain_js = options_js.get::<&str, JsObject>("coneOuterGain")?;
                 let cone_outer_gain = if let Some(cone_outer_gain_js) = some_cone_outer_gain_js {
-                    cone_outer_gain_js.get_double()?
+                    cone_outer_gain_js.coerce_to_number()?.get_double()?
                 } else {
                     0.
                 };
@@ -268,36 +268,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = PannerOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,
@@ -634,7 +638,7 @@ fn set_panning_model(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let js_str = ctx.get::<JsString>(0)?;
+    let js_str = ctx.get::<JsObject>(0)?.coerce_to_string()?;
     let utf8_str = js_str.into_utf8()?.into_owned()?;
     let value = match utf8_str.as_str() {
         "equalpower" => PanningModelType::EqualPower,
@@ -653,7 +657,7 @@ fn set_distance_model(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let js_str = ctx.get::<JsString>(0)?;
+    let js_str = ctx.get::<JsObject>(0)?.coerce_to_string()?;
     let utf8_str = js_str.into_utf8()?.into_owned()?;
     let value = match utf8_str.as_str() {
         "linear" => DistanceModelType::Linear,
@@ -673,7 +677,7 @@ fn set_ref_distance(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_ref_distance(value);
 
     ctx.env.get_undefined()
@@ -685,7 +689,7 @@ fn set_max_distance(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_max_distance(value);
 
     ctx.env.get_undefined()
@@ -697,7 +701,7 @@ fn set_rolloff_factor(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_rolloff_factor(value);
 
     ctx.env.get_undefined()
@@ -709,7 +713,7 @@ fn set_cone_inner_angle(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_cone_inner_angle(value);
 
     ctx.env.get_undefined()
@@ -721,7 +725,7 @@ fn set_cone_outer_angle(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_cone_outer_angle(value);
 
     ctx.env.get_undefined()
@@ -733,7 +737,7 @@ fn set_cone_outer_gain(ctx: CallContext) -> Result<JsUndefined> {
     let napi_node = ctx.env.unwrap::<NapiPannerNode>(&js_this)?;
     let node = napi_node.unwrap();
 
-    let value = ctx.get::<JsNumber>(0)?.get_double()?;
+    let value = ctx.get::<JsObject>(0)?.coerce_to_number()?.get_double()?;
     node.set_cone_outer_gain(value);
 
     ctx.env.get_undefined()
@@ -751,13 +755,13 @@ fn set_position(ctx: CallContext) -> Result<JsUndefined> {
     #[allow(unused_variables)]
     let node = napi_node.unwrap();
 
-    let x_js = ctx.get::<JsNumber>(0)?;
+    let x_js = ctx.get::<JsObject>(0)?.coerce_to_number()?;
     let x = x_js.get_double()? as f32;
 
-    let y_js = ctx.get::<JsNumber>(1)?;
+    let y_js = ctx.get::<JsObject>(1)?.coerce_to_number()?;
     let y = y_js.get_double()? as f32;
 
-    let z_js = ctx.get::<JsNumber>(2)?;
+    let z_js = ctx.get::<JsObject>(2)?.coerce_to_number()?;
     let z = z_js.get_double()? as f32;
 
     node.set_position(x, y, z);
@@ -773,13 +777,13 @@ fn set_orientation(ctx: CallContext) -> Result<JsUndefined> {
     #[allow(unused_variables)]
     let node = napi_node.unwrap();
 
-    let x_js = ctx.get::<JsNumber>(0)?;
+    let x_js = ctx.get::<JsObject>(0)?.coerce_to_number()?;
     let x = x_js.get_double()? as f32;
 
-    let y_js = ctx.get::<JsNumber>(1)?;
+    let y_js = ctx.get::<JsObject>(1)?.coerce_to_number()?;
     let y = y_js.get_double()? as f32;
 
-    let z_js = ctx.get::<JsNumber>(2)?;
+    let z_js = ctx.get::<JsObject>(2)?.coerce_to_number()?;
     let z = z_js.get_double()? as f32;
 
     node.set_orientation(x, y, z);

--- a/src/stereo_panner_node.rs
+++ b/src/stereo_panner_node.rs
@@ -80,10 +80,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/stereo_panner_node.rs
+++ b/src/stereo_panner_node.rs
@@ -82,23 +82,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'StereoPannerNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'StereoPannerNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'StereoPannerNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/src/stereo_panner_node.rs
+++ b/src/stereo_panner_node.rs
@@ -136,40 +136,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 StereoPannerOptions {
                     pan,
@@ -272,7 +274,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -305,7 +307,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/stereo_panner_node.rs
+++ b/src/stereo_panner_node.rs
@@ -74,8 +74,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
     if ctx.length < 1 {
-        let msg =
-            "Failed to construct 'StereoPannerNode': 1 argument required, but only 0 present.";
+        let msg = "TypeError - Failed to construct 'StereoPannerNode': 1 argument required, but only 0 present.";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     }
 
@@ -89,7 +88,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         let audio_context_str = &audio_context_utf8_name[..];
 
         if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
-            let msg = "Failed to construct 'StereoPannerNode': argument 0 should be an instance of BaseAudioContext";
+            let msg = "TypeError - Failed to construct 'StereoPannerNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
 
@@ -99,7 +98,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
         // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
         // > fatal runtime error: failed to initiate panic, error 5
-        let msg = "Failed to construct 'StereoPannerNode': argument 0 should be an instance of BaseAudioContext";
+        let msg = "TypeError - Failed to construct 'StereoPannerNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };
 
@@ -117,9 +116,9 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let options = if let Ok(either_options) = ctx.try_get::<JsObject>(1) {
         match either_options {
             Either::A(options_js) => {
-                let some_pan_js = options_js.get::<&str, JsNumber>("pan")?;
+                let some_pan_js = options_js.get::<&str, JsObject>("pan")?;
                 let pan = if let Some(pan_js) = some_pan_js {
-                    pan_js.get_double()? as f32
+                    pan_js.coerce_to_number()?.get_double()? as f32
                 } else {
                     0.
                 };
@@ -127,36 +126,40 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
                 let node_defaults = StereoPannerOptions::default();
                 let channel_config_defaults = node_defaults.channel_config;
 
-                let some_channel_count_js = options_js.get::<&str, JsNumber>("channelCount")?;
+                let some_channel_count_js = options_js.get::<&str, JsObject>("channelCount")?;
                 let channel_count = if let Some(channel_count_js) = some_channel_count_js {
-                    channel_count_js.get_double()? as usize
+                    channel_count_js.coerce_to_number()?.get_double()? as usize
                 } else {
                     channel_config_defaults.count
                 };
 
                 let some_channel_count_mode_js =
-                    options_js.get::<&str, JsString>("channelCountMode")?;
-                let channel_count_mode = if let Some(channel_count_mode_js) =
-                    some_channel_count_mode_js
-                {
-                    let channel_count_mode_str = channel_count_mode_js.into_utf8()?.into_owned()?;
+                    options_js.get::<&str, JsObject>("channelCountMode")?;
+                let channel_count_mode =
+                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
+                        let channel_count_mode_str = channel_count_mode_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
-                    match channel_count_mode_str.as_str() {
-                        "max" => ChannelCountMode::Max,
-                        "clamped-max" => ChannelCountMode::ClampedMax,
-                        "explicit" => ChannelCountMode::Explicit,
-                        _ => panic!("undefined value for ChannelCountMode"),
-                    }
-                } else {
-                    channel_config_defaults.count_mode
-                };
+                        match channel_count_mode_str.as_str() {
+                            "max" => ChannelCountMode::Max,
+                            "clamped-max" => ChannelCountMode::ClampedMax,
+                            "explicit" => ChannelCountMode::Explicit,
+                            _ => panic!("undefined value for ChannelCountMode"),
+                        }
+                    } else {
+                        channel_config_defaults.count_mode
+                    };
 
                 let some_channel_interpretation_js =
-                    options_js.get::<&str, JsString>("channelInterpretation")?;
+                    options_js.get::<&str, JsObject>("channelInterpretation")?;
                 let channel_interpretation =
                     if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str =
-                            channel_interpretation_js.into_utf8()?.into_owned()?;
+                        let channel_interpretation_str = channel_interpretation_js
+                            .coerce_to_string()?
+                            .into_utf8()?
+                            .into_owned()?;
 
                         match channel_interpretation_str.as_str() {
                             "speakers" => ChannelInterpretation::Speakers,

--- a/src/wave_shaper_node.rs
+++ b/src/wave_shaper_node.rs
@@ -159,40 +159,42 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
                 let some_channel_count_mode_js =
                     options_js.get::<&str, JsObject>("channelCountMode")?;
-                let channel_count_mode =
-                    if let Some(channel_count_mode_js) = some_channel_count_mode_js {
-                        let channel_count_mode_str = channel_count_mode_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_count_mode = if let Some(channel_count_mode_js) =
+                    some_channel_count_mode_js
+                {
+                    let channel_count_mode_str = channel_count_mode_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_count_mode_str.as_str() {
-                            "max" => ChannelCountMode::Max,
-                            "clamped-max" => ChannelCountMode::ClampedMax,
-                            "explicit" => ChannelCountMode::Explicit,
-                            _ => panic!("undefined value for ChannelCountMode"),
-                        }
-                    } else {
-                        channel_config_defaults.count_mode
-                    };
+                    match channel_count_mode_str.as_str() {
+                        "max" => ChannelCountMode::Max,
+                        "clamped-max" => ChannelCountMode::ClampedMax,
+                        "explicit" => ChannelCountMode::Explicit,
+                        _ => panic!("TypeError - Failed to read the 'channelCountMode' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelCountMode", channel_count_mode_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.count_mode
+                };
 
                 let some_channel_interpretation_js =
                     options_js.get::<&str, JsObject>("channelInterpretation")?;
-                let channel_interpretation =
-                    if let Some(channel_interpretation_js) = some_channel_interpretation_js {
-                        let channel_interpretation_str = channel_interpretation_js
-                            .coerce_to_string()?
-                            .into_utf8()?
-                            .into_owned()?;
+                let channel_interpretation = if let Some(channel_interpretation_js) =
+                    some_channel_interpretation_js
+                {
+                    let channel_interpretation_str = channel_interpretation_js
+                        .coerce_to_string()?
+                        .into_utf8()?
+                        .into_owned()?;
 
-                        match channel_interpretation_str.as_str() {
-                            "speakers" => ChannelInterpretation::Speakers,
-                            "discrete" => ChannelInterpretation::Discrete,
-                            _ => panic!("undefined value for ChannelInterpretation"),
-                        }
-                    } else {
-                        channel_config_defaults.interpretation
-                    };
+                    match channel_interpretation_str.as_str() {
+                        "speakers" => ChannelInterpretation::Speakers,
+                        "discrete" => ChannelInterpretation::Discrete,
+                        _ => panic!("TypeError - Failed to read the 'channelInterpretation' property from 'AudioNodeOptions': The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", channel_interpretation_str.as_str()),
+                    }
+                } else {
+                    channel_config_defaults.interpretation
+                };
 
                 WaveShaperOptions {
                     curve,
@@ -289,7 +291,7 @@ fn set_channel_count_mode(ctx: CallContext) -> Result<JsUndefined> {
         "max" => ChannelCountMode::Max,
         "clamped-max" => ChannelCountMode::ClampedMax,
         "explicit" => ChannelCountMode::Explicit,
-        _ => panic!("undefined value for ChannelCountMode"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelCountMode", utf8_str.as_str()),
     };
     node.set_channel_count_mode(value);
 
@@ -322,7 +324,7 @@ fn set_channel_interpretation(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "speakers" => ChannelInterpretation::Speakers,
         "discrete" => ChannelInterpretation::Discrete,
-        _ => panic!("undefined value for ChannelInterpretation"),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type ChannelInterpretation", utf8_str.as_str()),
     };
     node.set_channel_interpretation(value);
 

--- a/src/wave_shaper_node.rs
+++ b/src/wave_shaper_node.rs
@@ -87,10 +87,11 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // first argument should be an AudioContext
     let js_audio_context = ctx.get::<JsObject>(0)?;
+
     // check that
-    let audio_context_utf8_name = if let Ok(audio_context_name) =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")
-    {
+    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
+        let audio_context_name =
+            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
         let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
         let audio_context_str = &audio_context_utf8_name[..];
 

--- a/src/wave_shaper_node.rs
+++ b/src/wave_shaper_node.rs
@@ -89,23 +89,29 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let js_audio_context = ctx.get::<JsObject>(0)?;
 
     // check that
-    let audio_context_utf8_name = if js_audio_context.has_named_property("Symbol.toStringTag")? {
-        let audio_context_name =
-            js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-        let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-        let audio_context_str = &audio_context_utf8_name[..];
+    let audio_context_utf8_name = if let Ok(result) =
+        js_audio_context.has_named_property("Symbol.toStringTag")
+    {
+        if result {
+            let audio_context_name =
+                js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+            let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+            let audio_context_str = &audio_context_utf8_name[..];
 
-        if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+            if audio_context_str != "AudioContext" && audio_context_str != "OfflineAudioContext" {
+                let msg = "TypeError - Failed to construct 'WaveShaperNode': argument 1 is not of type BaseAudioContext";
+                return Err(napi::Error::new(napi::Status::InvalidArg, msg));
+            }
+
+            audio_context_utf8_name
+        } else {
             let msg = "TypeError - Failed to construct 'WaveShaperNode': argument 1 is not of type BaseAudioContext";
             return Err(napi::Error::new(napi::Status::InvalidArg, msg));
         }
-
-        audio_context_utf8_name
     } else {
-        // this crashes in debug mode but not in release mode, weird...
-        // > Throw error failed, status: [PendingException], raw message: "...", raw status: [InvalidArg]
-        // > note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace
-        // > fatal runtime error: failed to initiate panic, error 5
+        // This swallowed somehow, .e.g const node = new GainNode(null); throws
+        // TypeError Cannot convert undefined or null to object
+        // To be investigated...
         let msg = "TypeError - Failed to construct 'WaveShaperNode': argument 1 is not of type BaseAudioContext";
         return Err(napi::Error::new(napi::Status::InvalidArg, msg));
     };

--- a/tests/errors.mjs
+++ b/tests/errors.mjs
@@ -3,9 +3,10 @@ import { OfflineAudioContext } from '../index.mjs';
 const offline = new OfflineAudioContext(1, 1, 48000);
 
 const src = offline.createBufferSource();
+src.start(-1, 1, null);
 
 try {
-  src.start(-1.)
+  src.start(NaN);
 } catch (err) {
   console.log('final err:');
   console.log(err);

--- a/tests/errors.mjs
+++ b/tests/errors.mjs
@@ -1,0 +1,12 @@
+import { OfflineAudioContext } from '../index.mjs';
+
+const offline = new OfflineAudioContext(1, 1, 48000);
+
+const src = offline.createBufferSource();
+
+try {
+  src.start(-1.)
+} catch (err) {
+  console.log('final err:');
+  console.log(err);
+}

--- a/tests/wpt.mjs
+++ b/tests/wpt.mjs
@@ -1,7 +1,4 @@
 import { AnalyserNode, AudioContext, GainNode, OfflineAudioContext, mediaDevices } from '../index.mjs';
 
 const audioContext = new OfflineAudioContext(1, 1, 48000);
-// const node = new GainNode(audioContext);
-
-const node = new GainNode(audioContext, { channelCountMode: "foobar" });
-// node.channelCountMode
+const node = new GainNode(null);

--- a/tests/wpt.mjs
+++ b/tests/wpt.mjs
@@ -1,11 +1,20 @@
-import { OfflineAudioContext } from '../index.mjs';
+import { AudioContext, OfflineAudioContext, mediaDevices } from '../index.mjs';
 
-var off = new OfflineAudioContext(1, 512, 48000);
-var osc = new OscillatorNode(off);
-var fb = new GainNode(off);
-// zero delay feedback loop
-osc.connect(fb).connect(fb).connect(off.destination);
-osc.start(0);
-return off.startRendering().then((b) => {
-  return Promise.resolve(b.getChannelData(0));
+mediaDevices.enumerateDevices().then((deviceList) => {
+  const outputDeviceList =
+      deviceList.filter(({kind}) => kind === 'audiooutput');
+
+  console.log(outputDeviceList);
+  const firstDeviceId = outputDeviceList[1].deviceId;
+
+  const audioContext = new AudioContext({ sinkId: firstDeviceId });
+  audioContext.addEventListener('statechange', () => {
+    console.log(audioContext.sinkId === firstDeviceId,
+                  'the context sinkId should match the given sinkId.');
+    audioContext.close();
+    // t.done();
+  }, {once: true});
+
+  console.log('coucou');
+  audioContext.resume();
 });

--- a/tests/wpt.mjs
+++ b/tests/wpt.mjs
@@ -1,0 +1,11 @@
+import { OfflineAudioContext } from '../index.mjs';
+
+var off = new OfflineAudioContext(1, 512, 48000);
+var osc = new OscillatorNode(off);
+var fb = new GainNode(off);
+// zero delay feedback loop
+osc.connect(fb).connect(fb).connect(off.destination);
+osc.start(0);
+return off.startRendering().then((b) => {
+  return Promise.resolve(b.getChannelData(0));
+});

--- a/tests/wpt.mjs
+++ b/tests/wpt.mjs
@@ -1,4 +1,7 @@
-import { AnalyserNode, AudioContext, OfflineAudioContext, mediaDevices } from '../index.mjs';
+import { AnalyserNode, AudioContext, GainNode, OfflineAudioContext, mediaDevices } from '../index.mjs';
 
 const audioContext = new OfflineAudioContext(1, 1, 48000);
-const node = new AnalyserNode(1);
+// const node = new GainNode(audioContext);
+
+const node = new GainNode(audioContext, { channelCountMode: "foobar" });
+// node.channelCountMode

--- a/tests/wpt.mjs
+++ b/tests/wpt.mjs
@@ -1,20 +1,4 @@
-import { AudioContext, OfflineAudioContext, mediaDevices } from '../index.mjs';
+import { AnalyserNode, AudioContext, OfflineAudioContext, mediaDevices } from '../index.mjs';
 
-mediaDevices.enumerateDevices().then((deviceList) => {
-  const outputDeviceList =
-      deviceList.filter(({kind}) => kind === 'audiooutput');
-
-  console.log(outputDeviceList);
-  const firstDeviceId = outputDeviceList[1].deviceId;
-
-  const audioContext = new AudioContext({ sinkId: firstDeviceId });
-  audioContext.addEventListener('statechange', () => {
-    console.log(audioContext.sinkId === firstDeviceId,
-                  'the context sinkId should match the given sinkId.');
-    audioContext.close();
-    // t.done();
-  }, {once: true});
-
-  console.log('coucou');
-  audioContext.resume();
-});
+const audioContext = new OfflineAudioContext(1, 1, 48000);
+const node = new AnalyserNode(1);


### PR DESCRIPTION
Quite a massive one again, 

Still need to 
- [x] Handle simple errors that may occur here and there and that comes from the bindings, e.g.
```
[lib/errors.js] Unhandled error type Error undefined value for ChannelInterpretation
  | X new WaveShaperNode(c, {channelInterpretation: "foobar"}) threw "Error" instead of EcmaScript error TypeError.
```
- [x] Wrap the `AudioParam` interface 
- [ ] Wrap the `AudioBuffer` interface, but will do that later, not sure how to handle this case right now


Results so far:
```
  RESULTS:
  - # pass: 3740 (+135)
  - # fail: 1281 (-3)
  - # type error issues: 109 (-125)
```