### PR TITLE
Drop wpt fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wpt"]
 	path = wpt
-	url = git@github.com:orottier/wpt.git
+	url = git@github.com:web-platform-tests/wpt.git

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -75,6 +75,17 @@ const filter = (name) => {
   if (name.includes('/resources/')) {
       return false;
   }
+
+  // TODO <https://github.com/ircam-ismm/node-web-audio-api/issues/57>
+  // these tests make the runner crash
+  if (
+      name.includes('the-audiocontext-interface/suspend-with-navigation.html')
+      || name.includes('the-audionode-interface/audionode-disconnect-audioparam.html')
+      || name.includes('the-audionode-interface/audionode-disconnect.html')
+  ) {
+      return false;
+  }
+
   if (filterRe.test(name)) {
     if (options.list) {
       console.log(name);


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/43824 was merged and somehow we don't crash the runner for other 404s.
I have listed three remaining files to ignore in the wpt-harness.js now. I will add those as todo to #57 

```
  RESULTS:
  - # pass: 3856 (-2) 
  - # fail: 1226 (+10)
  - # type error issues: 63 (+1)
  - # files ignored: 3 (-5)
```