### PR TITLE
Upgrade to 0.42, fix wpt checkout, add channelCount to MediaTrackConstraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.15.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = {version="2.14", features=["napi9", "tokio_rt"]}
+napi = {version="=2.14", features=["napi9", "tokio_rt"]}
 napi-derive = "2.14"
 uuid = {version="1.6.1", features = ["v4","fast-rng"]}
 web-audio-api = "0.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 napi = {version="2.14", features=["napi9", "tokio_rt"]}
 napi-derive = "2.14"
 uuid = {version="1.6.1", features = ["v4","fast-rng"]}
-web-audio-api = "0.41.1"
+web-audio-api = "0.42"
 # web-audio-api = { path = "../web-audio-api-rs" }
 
 [target.'cfg(all(any(windows, unix), target_arch = "x86_64", not(target_env = "musl")))'.dependencies]

--- a/src/media_devices/get_user_media.rs
+++ b/src/media_devices/get_user_media.rs
@@ -47,6 +47,13 @@ pub(crate) fn napi_get_user_media(ctx: CallContext) -> Result<JsObject> {
                     constraints.latency = Some(latency);
                 }
 
+                if let Ok(Some(js_channel_count)) =
+                    js_constraints.get::<&str, JsNumber>("channelCount")
+                {
+                    let channel_count = js_channel_count.get_uint32()?;
+                    constraints.channel_count = Some(channel_count);
+                }
+
                 MediaStreamConstraints::AudioWithConstraints(constraints)
             } else {
                 return Err(napi::Error::from_reason(


### PR DESCRIPTION
@trevorparscal could you have a look if this works for you? I don't have a multichannel mic at hand here and the underlying `cpal` library is surprisingly relaxed in allowing exotic channel counts - so I can't really test properly myself.

Fixes #74 