### PR TITLE
Feat: run idlharness from wpt

### DIFF
--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -7,6 +7,7 @@ import * as nodeWebAudioAPI from '../index.mjs';
 
 // mocks
 import createXMLHttpRequest from './wpt-mock/XMLHttpRequest.js';
+import createFetch from './wpt-mock/fetch.js';
 import { DOMException } from '../js/lib/errors.js';
 
 program
@@ -31,6 +32,7 @@ function indent(string, times) {
 // -------------------------------------------------------
 // WPT Runner configuration options
 // -------------------------------------------------------
+const wptRootPath = path.join('wpt');
 const testsPath = path.join('wpt','webaudio');
 const rootURL = 'webaudio';
 
@@ -47,6 +49,7 @@ const setup = window => {
 
   // e.g. 'resources/audiobuffersource-multi-channels-expected.wav'
   window.XMLHttpRequest = createXMLHttpRequest(testsPath);
+  window.fetch = createFetch(wptRootPath);
   // window.requestAnimationFrame = func => setInterval(func, 16);
   // errors
   window.TypeError = TypeError;

--- a/.scripts/wpt-mock/fetch.js
+++ b/.scripts/wpt-mock/fetch.js
@@ -1,0 +1,26 @@
+// require in node_modules/wpt_runner/testharness/idlharness.js,  cf `fetch_spec`
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = function createFetch(basePath) {
+  return function fetch(pathname) {
+    pathname = path.join(basePath, pathname);
+
+    return new Promise(resolve => {
+      if (!fs.existsSync(pathname)) {
+        resolve({
+          ok: false,
+          msg: `file ${pathname} not found`,
+        });
+      } else {
+        const buffer = fs.readFileSync(pathname);
+
+        resolve({
+          ok: true,
+          text: () => buffer.toString(),
+        });
+      }
+    });
+  }
+};

--- a/.scripts/wpt-mock/fetch.js
+++ b/.scripts/wpt-mock/fetch.js
@@ -1,5 +1,4 @@
-// require in node_modules/wpt_runner/testharness/idlharness.js,  cf `fetch_spec`
-
+// required in node_modules/wpt_runner/testharness/idlharness.js, cf `fetch_spec`
 const fs = require('node:fs');
 const path = require('node:path');
 


### PR DESCRIPTION
Fix #86

```
$ npm run wpt:only -- --filter idlharness.https.window.html

RESULTS:
  - # pass: 613
  - # fail: 530
  - # type error issues: 0
```

Was finally just a missing mock for `fetch`, but a bit tricky to find as the `idlharness.js` file is copied inside wpt-runner 

(got lucky to find it, I think have stumbled on that "not fiddling in the right file and getting mad" quite a few times already...)