### PR TITLE
Fix type errors

### DIFF
--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -124,7 +124,7 @@ const reporter = {
   },
   pass: message => {
     numPass += 1;
-    console.log(chalk.dim(indent(chalk.green("√ ") + message, INDENT_SIZE)));
+    // console.log(chalk.dim(indent(chalk.green("√ ") + message, INDENT_SIZE)));
   },
   fail: message => {
     if (/threw "[^\"]*Error" instead of/.test(message)) {
@@ -132,7 +132,7 @@ const reporter = {
       console.log(chalk.bold.yellow(indent(`| ${message}`, INDENT_SIZE)));
     } else {
       numFail += 1;
-      console.log(chalk.bold.red(indent(`\u00D7 ${message}`, INDENT_SIZE)));
+      // console.log(chalk.bold.red(indent(`\u00D7 ${message}`, INDENT_SIZE)));
     }
   },
   reportStack: stack => {

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -58,18 +58,18 @@ const setup = window => {
   window.navigator.mediaDevices = nodeWebAudioAPI.mediaDevices;
   // window.MediaStream = nodeWebAudioAPI.mediaDevices.MediaStream;
 
-  // seems required (weirdly...), cf. `the-audiobuffer-interface/audiobuffer.html`
-  window.Float32Array = Float32Array;
-
   // e.g. 'resources/audiobuffersource-multi-channels-expected.wav'
   window.XMLHttpRequest = createXMLHttpRequest(testsPath);
   window.fetch = createFetch(wptRootPath);
   // window.requestAnimationFrame = func => setInterval(func, 16);
-  // errors
+
+  // populate window with node internals
   window.TypeError = TypeError;
   window.RangeError = RangeError;
   window.Error = Error;
   window.DOMException = DOMException;
+  window.Float32Array = Float32Array;
+  window.EventTarget = EventTarget;
 }
 
 // try catch unhandled error to prevent wpt process from crashing

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -125,7 +125,7 @@ const reporter = {
   },
   pass: message => {
     numPass += 1;
-    console.log(chalk.dim(indent(chalk.green("√ ") + message, INDENT_SIZE)));
+    // console.log(chalk.dim(indent(chalk.green("√ ") + message, INDENT_SIZE)));
   },
   fail: message => {
     if (/threw "[^\"]*Error" instead of/.test(message)) {

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -124,7 +124,7 @@ const reporter = {
   },
   pass: message => {
     numPass += 1;
-    // console.log(chalk.dim(indent(chalk.green("√ ") + message, INDENT_SIZE)));
+    console.log(chalk.dim(indent(chalk.green("√ ") + message, INDENT_SIZE)));
   },
   fail: message => {
     if (/threw "[^\"]*Error" instead of/.test(message)) {
@@ -132,7 +132,7 @@ const reporter = {
       console.log(chalk.bold.yellow(indent(`| ${message}`, INDENT_SIZE)));
     } else {
       numFail += 1;
-      // console.log(chalk.bold.red(indent(`\u00D7 ${message}`, INDENT_SIZE)));
+      console.log(chalk.bold.red(indent(`\u00D7 ${message}`, INDENT_SIZE)));
     }
   },
   reportStack: stack => {

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -70,6 +70,7 @@ const setup = window => {
   window.DOMException = DOMException;
   window.Float32Array = Float32Array;
   window.EventTarget = EventTarget;
+  window.Promise = Promise;
 }
 
 // try catch unhandled error to prevent wpt process from crashing

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -166,7 +166,6 @@ module.exports = (jsExport, nativeBinding) => {
               break;
             }
             default: {
-              d.debug(d.memberType(member))
               // - IIRFilterNode::feedback
               // - IIRFilterNode::feedforward
               // - WaveShaperNode:::curve
@@ -360,8 +359,8 @@ ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
 }).join('')}
 
 ${d.methods(d.node, false)
+  // dedup method names
   .reduce((acc, method) => {
-    // dedup method names
     if (!acc.find(i => d.name(i) === d.name(method))) {
       acc.push(method)
     }
@@ -371,9 +370,14 @@ ${d.methods(d.node, false)
   .filter(method => d.name(method) !== 'start' && d.name(method) !== 'stop')
   .map(method => {
     const numRequired = d.minRequiredArgs(method);
+    const argumentNames = method.arguments.filter(arg => arg.optional === false).map(d.name);
+    // make sure we can assume that all arguments are required
+    if (argumentNames.length !== method.arguments.length) {
+      console.log(`> Warning: optionnal argument for ${d.name(method)}`)
+    }
 
     return `
-    ${d.name(method)}(...args) {
+    ${d.name(method)}(${argumentNames.join(', ')}) {
       if (!(this instanceof ${d.name(d.node)})) {
         throw new TypeError("Invalid Invocation: Value of 'this' must be of type '${d.name(d.node)}'");
       }
@@ -382,13 +386,54 @@ ${d.methods(d.node, false)
         throw new TypeError(\`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': ${numRequired} argument required, but only \${arguments.length}\ present\`);
       }
 
-      ${method.arguments[0].idlType.idlType === 'PeriodicWave'
-        ? `args[0] = args[0][kNapiObj];`
-        : ``
+      ${method.arguments.map((argument, index) => {
+        const name = d.name(argument);
+        const type = argument.idlType.idlType;
+
+        switch (type) {
+          case 'float': {
+            return `
+      ${name} = conversions['${type}'](${name}, {
+        context: \`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': Parameter ${index + 1}\`,
+      });
+            `
+            break;
+          }
+          case 'Float32Array': {
+            return `
+      if (!(${name} instanceof Float32Array)) {
+        throw new TypeError(\`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': Parameter ${index + 1} is not of type 'Float32Array'\`);
+      }
+            `;
+            break;
+          }
+          case 'Uint8Array': {
+            return `
+      if (!(${name} instanceof Uint8Array)) {
+        throw new TypeError(\`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': Parameter ${index + 1} is not of type 'Uint8Array'\`);
+      }
+            `;
+            break;
+          }
+          case 'PeriodicWave': {
+            return `
+      if (!(${name} instanceof jsExport.PeriodicWave)) {
+        throw new TypeError(\`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': Parameter ${index + 1} is not of type 'PeriodicWave'\`);
       }
 
+      ${name} = ${name}[kNapiObj];
+            `;
+            break;
+          }
+          default: {
+            console.log('unhandle type', type, 'in method', d.name(method));
+            break;
+          }
+        }
+      }).join('')}
+
       try {
-        return this[kNapiObj].${d.name(method)}(...args);
+        return this[kNapiObj].${d.name(method)}(${argumentNames.join(', ')});
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -420,15 +465,12 @@ ${(function() {
       configurable: true,
       value: '${d.name(d.node)}',
     },
-
     ${d.audioParams(d.node).map(param => {
       return `${d.name(param)}: kEnumerableProperty,`;
     }).join('')}
-
     ${d.attributes(d.node).map(attr => {
       return `${d.name(attr)}: kEnumerableProperty,`;
     }).join('')}
-
     ${d.methods(d.node, false)
       .reduce((acc, method) => {
         // dedup method names
@@ -443,28 +485,6 @@ ${(function() {
         return `${d.name(method)}: kEnumerableProperty,`;
       }).join('')}
   });
-
-  ${d.methods(d.node, false)
-    .reduce((acc, method) => {
-      // dedup method names
-      if (!acc.find(i => d.name(i) === d.name(method))) {
-        acc.push(method)
-      }
-      return acc;
-    }, [])
-    // filter AudioScheduledSourceNode methods to prevent re-throwing errors
-    .filter(method => d.name(method) !== 'start' && d.name(method) !== 'stop')
-    .map(method => {
-      return `
-  Object.defineProperty(${d.name(d.node)}.prototype.${d.name(method)}, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: ${d.minRequiredArgs(method)}
-  });
-      `
-    }).join('')}
   `;
 }())}
 

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -396,7 +396,7 @@ ${d.methods(d.node, false)
       ${name} = conversions['${type}'](${name}, {
         context: \`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': Parameter ${index + 1}\`,
       });
-            `
+            `;
             break;
           }
           case 'Float32Array': {

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -70,7 +70,7 @@ module.exports = (jsExport, nativeBinding) => {
           if (required) {
           checkMember += `
       // required options
-      if (typeof options !== 'object' || (options && !('${optionName}' in options))) {
+      if (typeof options !== 'object' || (options && options.${optionName} === undefined)) {
         throw new TypeError("Failed to construct '${d.name(d.node)}': Failed to read the '${optionName}'' property from ${optionsType}: Required member is undefined");
       }
           `

--- a/generator/js/AudioParam.tmpl.js
+++ b/generator/js/AudioParam.tmpl.js
@@ -58,10 +58,12 @@ ${d.methods(d.node, false).reduce((acc, method) => {
     }
 
     try {
-      return this[kNativeAudioParam].${d.name(method)}(...args);
+      this[kNativeAudioParam].${d.name(method)}(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 `}).join('')}
 }

--- a/generator/js/AudioParam.tmpl.js
+++ b/generator/js/AudioParam.tmpl.js
@@ -1,5 +1,7 @@
-const { throwSanitizedError } = require('./lib/errors.js');
+const conversions = require("webidl-conversions");
 
+const { toSanitizedSequence } = require('./lib/cast.js');
+const { throwSanitizedError } = require('./lib/errors.js');
 const { kEnumerableProperty } = require('./lib/utils.js');
 const { kNativeAudioParam } = require('./lib/symbols.js');
 
@@ -24,11 +26,21 @@ ${d.attributes(d.node).map(attr => {
 `}).join('')}
   // setters
 ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
+  // float or AutomationRate
+  const type = attr.idlType.idlType;
+  const castType = type === 'float' ? 'float' : 'string';
+
   return `
   set ${d.name(attr)}(value) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError("Invalid Invocation: Value of 'this' must be of type 'AudioParam'");
     }
+
+    ${type === 'float' ? `
+    value = conversions['${type}'](value, {
+      context: \`Failed to set the '${d.name(attr)}' property on '${d.name(d.node)}': The provided ${type} value\`,
+    });
+    ` : ``}
 
     try {
       this[kNativeAudioParam].${d.name(attr)} = value;
@@ -38,17 +50,23 @@ ${d.attributes(d.node).filter(attr => !attr.readonly).map(attr => {
   }
 `}).join('')}
   // methods
-${d.methods(d.node, false).reduce((acc, method) => {
-  // dedup method names
-  if (!acc.find(i => d.name(i) === d.name(method))) {
-    acc.push(method)
-  }
-  return acc;
-}, []).map(method => {
-  const numRequired = d.minRequiredArgs(method);
+${d.methods(d.node, false)
+  .reduce((acc, method) => {
+    // dedup method names
+    if (!acc.find(i => d.name(i) === d.name(method))) {
+      acc.push(method)
+    }
+    return acc;
+  }, []).map(method => {
+    const numRequired = d.minRequiredArgs(method);
+    const argumentNames = method.arguments.filter(arg => arg.optional === false).map(d.name);
+    // make sure we can assume that all arguments are required
+    if (argumentNames.length !== method.arguments.length) {
+      console.log(`> Warning: optionnal argument for ${d.name(method)}`)
+    }
 
-  return `
-  ${d.name(method)}(...args) {
+    return `
+  ${d.name(method)}(${argumentNames.join(', ')}) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError("Invalid Invocation: Value of 'this' must be of type 'AudioParam'");
     }
@@ -57,15 +75,48 @@ ${d.methods(d.node, false).reduce((acc, method) => {
       throw new TypeError(\`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': ${numRequired} argument required, but only \${arguments.length}\ present\`);
     }
 
+    ${method.arguments.map((argument, index) => {
+      const name = d.name(argument);
+      const type = argument.idlType.idlType;
+
+      switch (type) {
+        case 'float':
+        case 'double': {
+          return `
+    ${name} = conversions['${type}'](${name}, {
+      context: \`Failed to execute '${d.name(method)}' on '${d.name(d.node)}': Parameter ${index + 1}\`,
+    });
+          `;
+          break;
+        }
+        default: {
+          if (argument.idlType.generic === 'sequence' && argument.idlType.idlType[0].idlType === 'float') {
+            return `
     try {
-      this[kNativeAudioParam].${d.name(method)}(...args);
+      ${name} = toSanitizedSequence(${name}, Float32Array);
+    } catch (err) {
+      throw new TypeError(\`Failed to execute '${d.name(method)}': Parameter ${index + 1} \${err.message}\`);
+    }
+            `;
+          } else {
+            console.log(`> Warning: argument type not handled`);
+            d.debug(argument);
+          }
+          break;
+        }
+      }
+    }).join('')}
+
+    try {
+      this[kNativeAudioParam].${d.name(method)}(${argumentNames.join(', ')});
     } catch (err) {
       throwSanitizedError(err);
     }
 
     return this;
   }
-`}).join('')}
+    `
+  }).join('')}
 }
 
 Object.defineProperties(AudioParam, {

--- a/generator/rs/audio_param.tmpl.rs
+++ b/generator/rs/audio_param.tmpl.rs
@@ -75,7 +75,7 @@ fn set_automation_rate(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "a-rate" => AutomationRate::A,
         "k-rate" => AutomationRate::K,
-        _ => panic!("The provided value '{:?}' is not a valid enum value of type AutomationRate.", utf8_str),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type AutomationRate.", utf8_str),
     };
     obj.set_automation_rate(value);
 

--- a/js/AnalyserNode.js
+++ b/js/AnalyserNode.js
@@ -197,7 +197,7 @@ module.exports = (jsExport, nativeBinding) => {
       }
     }
 
-    getFloatFrequencyData(...args) {
+    getFloatFrequencyData(array) {
       if (!(this instanceof AnalyserNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AnalyserNode\'');
       }
@@ -206,14 +206,18 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'getFloatFrequencyData' on 'AnalyserNode': 1 argument required, but only ${arguments.length} present`);
       }
 
+      if (!(array instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFloatFrequencyData' on 'AnalyserNode': Parameter 1 is not of type 'Float32Array'`);
+      }
+
       try {
-        return this[kNapiObj].getFloatFrequencyData(...args);
+        return this[kNapiObj].getFloatFrequencyData(array);
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    getByteFrequencyData(...args) {
+    getByteFrequencyData(array) {
       if (!(this instanceof AnalyserNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AnalyserNode\'');
       }
@@ -222,14 +226,18 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'getByteFrequencyData' on 'AnalyserNode': 1 argument required, but only ${arguments.length} present`);
       }
 
+      if (!(array instanceof Uint8Array)) {
+        throw new TypeError(`Failed to execute 'getByteFrequencyData' on 'AnalyserNode': Parameter 1 is not of type 'Uint8Array'`);
+      }
+
       try {
-        return this[kNapiObj].getByteFrequencyData(...args);
+        return this[kNapiObj].getByteFrequencyData(array);
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    getFloatTimeDomainData(...args) {
+    getFloatTimeDomainData(array) {
       if (!(this instanceof AnalyserNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AnalyserNode\'');
       }
@@ -238,14 +246,18 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'getFloatTimeDomainData' on 'AnalyserNode': 1 argument required, but only ${arguments.length} present`);
       }
 
+      if (!(array instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFloatTimeDomainData' on 'AnalyserNode': Parameter 1 is not of type 'Float32Array'`);
+      }
+
       try {
-        return this[kNapiObj].getFloatTimeDomainData(...args);
+        return this[kNapiObj].getFloatTimeDomainData(array);
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    getByteTimeDomainData(...args) {
+    getByteTimeDomainData(array) {
       if (!(this instanceof AnalyserNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AnalyserNode\'');
       }
@@ -254,8 +266,12 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'getByteTimeDomainData' on 'AnalyserNode': 1 argument required, but only ${arguments.length} present`);
       }
 
+      if (!(array instanceof Uint8Array)) {
+        throw new TypeError(`Failed to execute 'getByteTimeDomainData' on 'AnalyserNode': Parameter 1 is not of type 'Uint8Array'`);
+      }
+
       try {
-        return this[kNapiObj].getByteTimeDomainData(...args);
+        return this[kNapiObj].getByteTimeDomainData(array);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -287,43 +303,10 @@ module.exports = (jsExport, nativeBinding) => {
     minDecibels: kEnumerableProperty,
     maxDecibels: kEnumerableProperty,
     smoothingTimeConstant: kEnumerableProperty,
-
     getFloatFrequencyData: kEnumerableProperty,
     getByteFrequencyData: kEnumerableProperty,
     getFloatTimeDomainData: kEnumerableProperty,
     getByteTimeDomainData: kEnumerableProperty,
-  });
-
-  Object.defineProperty(AnalyserNode.prototype.getFloatFrequencyData, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 1,
-  });
-
-  Object.defineProperty(AnalyserNode.prototype.getByteFrequencyData, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 1,
-  });
-
-  Object.defineProperty(AnalyserNode.prototype.getFloatTimeDomainData, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 1,
-  });
-
-  Object.defineProperty(AnalyserNode.prototype.getByteTimeDomainData, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 1,
   });
 
   return AnalyserNode;

--- a/js/AudioBuffer.js
+++ b/js/AudioBuffer.js
@@ -1,3 +1,5 @@
+const conversions = require("webidl-conversions");
+
 const { throwSanitizedError, DOMException } = require('./lib/errors.js');
 const { kEnumerableProperty } = require('./lib/utils.js');
 
@@ -70,9 +72,18 @@ module.exports.AudioBuffer = (NativeAudioBuffer) => {
       }
 
       // rust implementation uses a usize so this check must be done here
+      // weirdly `conversions['unsigned long'](-1);` returns `4294967295``
       if (channelNumber < 0) {
         throw new DOMException(`Failed to execute 'copyFromChannel' on 'AudioBuffer': channelNumber must equal or greater than 0`, 'IndexSizeError');
       }
+
+      channelNumber = conversions['unsigned long'](channelNumber);
+
+      if (channelNumber < 0) {
+        throw new DOMException(`Failed to execute 'copyFromChannel' on 'AudioBuffer': bufferOffset must equal or greater than 0`, 'IndexSizeError');
+      }
+
+      bufferOffset = conversions['unsigned long'](bufferOffset);
 
       try {
         this[kNativeAudioBuffer].copyFromChannel(destination, channelNumber, bufferOffset);
@@ -91,9 +102,18 @@ module.exports.AudioBuffer = (NativeAudioBuffer) => {
       }
 
       // rust implementation uses a usize so this check must be done here
+      // weirdly `conversions['unsigned long'](-1);` returns `4294967295``
       if (channelNumber < 0) {
         throw new DOMException(`Failed to execute 'copyToChannel' on 'AudioBuffer': channelNumber must equal or greater than 0`, 'IndexSizeError');
       }
+
+      channelNumber = conversions['unsigned long'](channelNumber);
+
+      if (channelNumber < 0) {
+        throw new DOMException(`Failed to execute 'copyToChannel' on 'AudioBuffer': bufferOffset must equal or greater than 0`, 'IndexSizeError');
+      }
+
+      bufferOffset = conversions['unsigned long'](bufferOffset);
 
       try {
         this[kNativeAudioBuffer].copyToChannel(source, channelNumber, bufferOffset);
@@ -106,6 +126,14 @@ module.exports.AudioBuffer = (NativeAudioBuffer) => {
       if (!(this instanceof AudioBuffer)) {
         throw new TypeError("Invalid Invocation: Value of 'this' must be of type 'AudioBuffer'");
       }
+
+      // rust implementation uses a usize so this check must be done here
+      // weirdly `conversions['unsigned long'](-1);` returns `4294967295``
+      if (channel < 0) {
+        throw new DOMException(`Failed to execute 'getChannelData' on 'AudioBuffer': channel must equal or greater than 0`, 'IndexSizeError');
+      }
+
+      channel = conversions['unsigned long'](channel);
 
       try {
         return this[kNativeAudioBuffer].getChannelData(channel);

--- a/js/AudioBufferSourceNode.js
+++ b/js/AudioBufferSourceNode.js
@@ -271,10 +271,8 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'AudioBufferSourceNode',
     },
-
     playbackRate: kEnumerableProperty,
     detune: kEnumerableProperty,
-
     buffer: kEnumerableProperty,
     loop: kEnumerableProperty,
     loopStart: kEnumerableProperty,

--- a/js/AudioContext.js
+++ b/js/AudioContext.js
@@ -1,5 +1,5 @@
 const { throwSanitizedError } = require('./lib/errors.js');
-const { isFunction, kEnumerableProperty } = require('./lib/utils.js');
+const { isFunction, isPlainObject, kEnumerableProperty } = require('./lib/utils.js');
 const { kNapiObj } = require('./lib/symbols.js');
 const { bridgeEventTarget } = require('./lib/events.js');
 
@@ -28,6 +28,10 @@ const kKeepAwakeId = Symbol('keepAwakeId');
 module.exports = function(jsExport, nativeBinding) {
   class AudioContext extends jsExport.BaseAudioContext {
     constructor(options = {}) {
+      if (!isPlainObject(options)) {
+        throw new TypeError(`Failed to construct 'AudioContext': The provided value is not of type 'AudioContextOptions'`);
+      }
+
       let napiObj;
 
       try {

--- a/js/AudioParam.js
+++ b/js/AudioParam.js
@@ -116,10 +116,12 @@ class AudioParam {
     }
 
     try {
-      return this[kNativeAudioParam].setValueAtTime(...args);
+      this[kNativeAudioParam].setValueAtTime(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 
   linearRampToValueAtTime(...args) {
@@ -132,10 +134,12 @@ class AudioParam {
     }
 
     try {
-      return this[kNativeAudioParam].linearRampToValueAtTime(...args);
+      this[kNativeAudioParam].linearRampToValueAtTime(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 
   exponentialRampToValueAtTime(...args) {
@@ -148,10 +152,12 @@ class AudioParam {
     }
 
     try {
-      return this[kNativeAudioParam].exponentialRampToValueAtTime(...args);
+      this[kNativeAudioParam].exponentialRampToValueAtTime(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 
   setTargetAtTime(...args) {
@@ -164,10 +170,12 @@ class AudioParam {
     }
 
     try {
-      return this[kNativeAudioParam].setTargetAtTime(...args);
+      this[kNativeAudioParam].setTargetAtTime(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 
   setValueCurveAtTime(...args) {
@@ -180,10 +188,12 @@ class AudioParam {
     }
 
     try {
-      return this[kNativeAudioParam].setValueCurveAtTime(...args);
+      this[kNativeAudioParam].setValueCurveAtTime(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 
   cancelScheduledValues(...args) {
@@ -196,10 +206,12 @@ class AudioParam {
     }
 
     try {
-      return this[kNativeAudioParam].cancelScheduledValues(...args);
+      this[kNativeAudioParam].cancelScheduledValues(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 
   cancelAndHoldAtTime(...args) {
@@ -212,10 +224,12 @@ class AudioParam {
     }
 
     try {
-      return this[kNativeAudioParam].cancelAndHoldAtTime(...args);
+      this[kNativeAudioParam].cancelAndHoldAtTime(...args);
     } catch (err) {
       throwSanitizedError(err);
     }
+
+    return this;
   }
 
 }

--- a/js/AudioParam.js
+++ b/js/AudioParam.js
@@ -17,10 +17,14 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
+const conversions = require('webidl-conversions');
+
+const {
+  toSanitizedSequence,
+} = require('./lib/cast.js');
 const {
   throwSanitizedError,
 } = require('./lib/errors.js');
-
 const {
   kEnumerableProperty,
 } = require('./lib/utils.js');
@@ -85,6 +89,10 @@ class AudioParam {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
 
+    value = conversions['float'](value, {
+      context: `Failed to set the 'value' property on 'AudioParam': The provided float value`,
+    });
+
     try {
       this[kNativeAudioParam].value = value;
     } catch (err) {
@@ -106,7 +114,7 @@ class AudioParam {
 
   // methods
 
-  setValueAtTime(...args) {
+  setValueAtTime(value, startTime) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
@@ -115,8 +123,16 @@ class AudioParam {
       throw new TypeError(`Failed to execute 'setValueAtTime' on 'AudioParam': 2 argument required, but only ${arguments.length} present`);
     }
 
+    value = conversions['float'](value, {
+      context: `Failed to execute 'setValueAtTime' on 'AudioParam': Parameter 1`,
+    });
+
+    startTime = conversions['double'](startTime, {
+      context: `Failed to execute 'setValueAtTime' on 'AudioParam': Parameter 2`,
+    });
+
     try {
-      this[kNativeAudioParam].setValueAtTime(...args);
+      this[kNativeAudioParam].setValueAtTime(value, startTime);
     } catch (err) {
       throwSanitizedError(err);
     }
@@ -124,7 +140,7 @@ class AudioParam {
     return this;
   }
 
-  linearRampToValueAtTime(...args) {
+  linearRampToValueAtTime(value, endTime) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
@@ -133,8 +149,16 @@ class AudioParam {
       throw new TypeError(`Failed to execute 'linearRampToValueAtTime' on 'AudioParam': 2 argument required, but only ${arguments.length} present`);
     }
 
+    value = conversions['float'](value, {
+      context: `Failed to execute 'linearRampToValueAtTime' on 'AudioParam': Parameter 1`,
+    });
+
+    endTime = conversions['double'](endTime, {
+      context: `Failed to execute 'linearRampToValueAtTime' on 'AudioParam': Parameter 2`,
+    });
+
     try {
-      this[kNativeAudioParam].linearRampToValueAtTime(...args);
+      this[kNativeAudioParam].linearRampToValueAtTime(value, endTime);
     } catch (err) {
       throwSanitizedError(err);
     }
@@ -142,7 +166,7 @@ class AudioParam {
     return this;
   }
 
-  exponentialRampToValueAtTime(...args) {
+  exponentialRampToValueAtTime(value, endTime) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
@@ -151,8 +175,16 @@ class AudioParam {
       throw new TypeError(`Failed to execute 'exponentialRampToValueAtTime' on 'AudioParam': 2 argument required, but only ${arguments.length} present`);
     }
 
+    value = conversions['float'](value, {
+      context: `Failed to execute 'exponentialRampToValueAtTime' on 'AudioParam': Parameter 1`,
+    });
+
+    endTime = conversions['double'](endTime, {
+      context: `Failed to execute 'exponentialRampToValueAtTime' on 'AudioParam': Parameter 2`,
+    });
+
     try {
-      this[kNativeAudioParam].exponentialRampToValueAtTime(...args);
+      this[kNativeAudioParam].exponentialRampToValueAtTime(value, endTime);
     } catch (err) {
       throwSanitizedError(err);
     }
@@ -160,7 +192,7 @@ class AudioParam {
     return this;
   }
 
-  setTargetAtTime(...args) {
+  setTargetAtTime(target, startTime, timeConstant) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
@@ -169,8 +201,20 @@ class AudioParam {
       throw new TypeError(`Failed to execute 'setTargetAtTime' on 'AudioParam': 3 argument required, but only ${arguments.length} present`);
     }
 
+    target = conversions['float'](target, {
+      context: `Failed to execute 'setTargetAtTime' on 'AudioParam': Parameter 1`,
+    });
+
+    startTime = conversions['double'](startTime, {
+      context: `Failed to execute 'setTargetAtTime' on 'AudioParam': Parameter 2`,
+    });
+
+    timeConstant = conversions['float'](timeConstant, {
+      context: `Failed to execute 'setTargetAtTime' on 'AudioParam': Parameter 3`,
+    });
+
     try {
-      this[kNativeAudioParam].setTargetAtTime(...args);
+      this[kNativeAudioParam].setTargetAtTime(target, startTime, timeConstant);
     } catch (err) {
       throwSanitizedError(err);
     }
@@ -178,7 +222,7 @@ class AudioParam {
     return this;
   }
 
-  setValueCurveAtTime(...args) {
+  setValueCurveAtTime(values, startTime, duration) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
@@ -188,7 +232,21 @@ class AudioParam {
     }
 
     try {
-      this[kNativeAudioParam].setValueCurveAtTime(...args);
+      values = toSanitizedSequence(values, Float32Array);
+    } catch (err) {
+      throw new TypeError(`Failed to execute 'setValueCurveAtTime': Parameter 1 ${err.message}`);
+    }
+
+    startTime = conversions['double'](startTime, {
+      context: `Failed to execute 'setValueCurveAtTime' on 'AudioParam': Parameter 2`,
+    });
+
+    duration = conversions['double'](duration, {
+      context: `Failed to execute 'setValueCurveAtTime' on 'AudioParam': Parameter 3`,
+    });
+
+    try {
+      this[kNativeAudioParam].setValueCurveAtTime(values, startTime, duration);
     } catch (err) {
       throwSanitizedError(err);
     }
@@ -196,7 +254,7 @@ class AudioParam {
     return this;
   }
 
-  cancelScheduledValues(...args) {
+  cancelScheduledValues(cancelTime) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
@@ -205,8 +263,12 @@ class AudioParam {
       throw new TypeError(`Failed to execute 'cancelScheduledValues' on 'AudioParam': 1 argument required, but only ${arguments.length} present`);
     }
 
+    cancelTime = conversions['double'](cancelTime, {
+      context: `Failed to execute 'cancelScheduledValues' on 'AudioParam': Parameter 1`,
+    });
+
     try {
-      this[kNativeAudioParam].cancelScheduledValues(...args);
+      this[kNativeAudioParam].cancelScheduledValues(cancelTime);
     } catch (err) {
       throwSanitizedError(err);
     }
@@ -214,7 +276,7 @@ class AudioParam {
     return this;
   }
 
-  cancelAndHoldAtTime(...args) {
+  cancelAndHoldAtTime(cancelTime) {
     if (!(this instanceof AudioParam)) {
       throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioParam\'');
     }
@@ -223,8 +285,12 @@ class AudioParam {
       throw new TypeError(`Failed to execute 'cancelAndHoldAtTime' on 'AudioParam': 1 argument required, but only ${arguments.length} present`);
     }
 
+    cancelTime = conversions['double'](cancelTime, {
+      context: `Failed to execute 'cancelAndHoldAtTime' on 'AudioParam': Parameter 1`,
+    });
+
     try {
-      this[kNativeAudioParam].cancelAndHoldAtTime(...args);
+      this[kNativeAudioParam].cancelAndHoldAtTime(cancelTime);
     } catch (err) {
       throwSanitizedError(err);
     }

--- a/js/BaseAudioContext.js
+++ b/js/BaseAudioContext.js
@@ -113,7 +113,7 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
     // when decodeErrorCallback is present the program will crash in an
     // unexpected manner
     // cf. https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata
-    decodeAudioData(audioData, decodeSuccessCallback = null, decodeErrorCallback = null) {
+    decodeAudioData(arrayBuffer, decodeSuccessCallback = undefined, decodeErrorCallback = undefined) {
       if (!(this instanceof BaseAudioContext)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
@@ -122,12 +122,12 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError(`Failed to execute 'decodeAudioData' on 'BaseAudioContext': 1 argument required, but only ${arguments.length} present`);
       }
 
-      if (!(audioData instanceof ArrayBuffer)) {
+      if (!(arrayBuffer instanceof ArrayBuffer)) {
         throw new TypeError('Failed to execute "decodeAudioData": parameter 1 is not of type "ArrayBuffer"');
       }
 
       try {
-        const nativeAudioBuffer = this[kNapiObj].decodeAudioData(audioData);
+        const nativeAudioBuffer = this[kNapiObj].decodeAudioData(arrayBuffer);
         const audioBuffer = new jsExport.AudioBuffer({
           [kNativeAudioBuffer]: nativeAudioBuffer,
         });
@@ -202,7 +202,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.AnalyserNode(this);
+      const options = {};
+
+      return new jsExport.AnalyserNode(this, options);
     }
 
     createBufferSource() {
@@ -210,7 +212,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.AudioBufferSourceNode(this);
+      const options = {};
+
+      return new jsExport.AudioBufferSourceNode(this, options);
     }
 
     createBiquadFilter() {
@@ -218,33 +222,31 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.BiquadFilterNode(this);
+      const options = {};
+
+      return new jsExport.BiquadFilterNode(this, options);
     }
 
-    createChannelMerger(numberOfInputs) {
+    createChannelMerger(numberOfInputs = 6) {
       if (!(this instanceof BaseAudioContext)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      const options = {};
-
-      if (numberOfInputs !== undefined) {
-        options.numberOfInputs = numberOfInputs;
-      }
+      const options = {
+        numberOfInputs,
+      };
 
       return new jsExport.ChannelMergerNode(this, options);
     }
 
-    createChannelSplitter(numberOfOutputs) {
+    createChannelSplitter(numberOfOutputs = 6) {
       if (!(this instanceof BaseAudioContext)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      const options = {};
-
-      if (numberOfOutputs !== undefined) {
-        options.numberOfOutputs = numberOfOutputs;
-      }
+      const options = {
+        numberOfOutputs,
+      };
 
       return new jsExport.ChannelSplitterNode(this, options);
     }
@@ -254,7 +256,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.ConstantSourceNode(this);
+      const options = {};
+
+      return new jsExport.ConstantSourceNode(this, options);
     }
 
     createConvolver() {
@@ -262,19 +266,19 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.ConvolverNode(this);
+      const options = {};
+
+      return new jsExport.ConvolverNode(this, options);
     }
 
-    createDelay(maxDelayTime) {
+    createDelay(maxDelayTime = 1.0) {
       if (!(this instanceof BaseAudioContext)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      const options = {};
-
-      if (maxDelayTime !== undefined) {
-        options.maxDelayTime = maxDelayTime;
-      }
+      const options = {
+        maxDelayTime,
+      };
 
       return new jsExport.DelayNode(this, options);
     }
@@ -284,7 +288,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.DynamicsCompressorNode(this);
+      const options = {};
+
+      return new jsExport.DynamicsCompressorNode(this, options);
     }
 
     createGain() {
@@ -292,7 +298,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.GainNode(this);
+      const options = {};
+
+      return new jsExport.GainNode(this, options);
     }
 
     createIIRFilter(feedforward, feedback) {
@@ -300,15 +308,10 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      const options = {};
-
-      if (feedforward !== undefined) {
-        options.feedforward = feedforward;
-      }
-
-      if (feedback !== undefined) {
-        options.feedback = feedback;
-      }
+      const options = {
+        feedforward,
+        feedback,
+      };
 
       return new jsExport.IIRFilterNode(this, options);
     }
@@ -318,7 +321,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.OscillatorNode(this);
+      const options = {};
+
+      return new jsExport.OscillatorNode(this, options);
     }
 
     createPanner() {
@@ -326,7 +331,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.PannerNode(this);
+      const options = {};
+
+      return new jsExport.PannerNode(this, options);
     }
 
     createStereoPanner() {
@@ -334,7 +341,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.StereoPannerNode(this);
+      const options = {};
+
+      return new jsExport.StereoPannerNode(this, options);
     }
 
     createWaveShaper() {
@@ -342,7 +351,9 @@ module.exports = (jsExport /*, nativeBinding */ ) => {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
       }
 
-      return new jsExport.WaveShaperNode(this);
+      const options = {};
+
+      return new jsExport.WaveShaperNode(this, options);
     }
 
   }

--- a/js/BiquadFilterNode.js
+++ b/js/BiquadFilterNode.js
@@ -180,7 +180,7 @@ module.exports = (jsExport, nativeBinding) => {
       }
     }
 
-    getFrequencyResponse(...args) {
+    getFrequencyResponse(frequencyHz, magResponse, phaseResponse) {
       if (!(this instanceof BiquadFilterNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BiquadFilterNode\'');
       }
@@ -189,8 +189,20 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'BiquadFilterNode': 3 argument required, but only ${arguments.length} present`);
       }
 
+      if (!(frequencyHz instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'BiquadFilterNode': Parameter 1 is not of type 'Float32Array'`);
+      }
+
+      if (!(magResponse instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'BiquadFilterNode': Parameter 2 is not of type 'Float32Array'`);
+      }
+
+      if (!(phaseResponse instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'BiquadFilterNode': Parameter 3 is not of type 'Float32Array'`);
+      }
+
       try {
-        return this[kNapiObj].getFrequencyResponse(...args);
+        return this[kNapiObj].getFrequencyResponse(frequencyHz, magResponse, phaseResponse);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -216,23 +228,12 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'BiquadFilterNode',
     },
-
     frequency: kEnumerableProperty,
     detune: kEnumerableProperty,
     Q: kEnumerableProperty,
     gain: kEnumerableProperty,
-
     type: kEnumerableProperty,
-
     getFrequencyResponse: kEnumerableProperty,
-  });
-
-  Object.defineProperty(BiquadFilterNode.prototype.getFrequencyResponse, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 3,
   });
 
   return BiquadFilterNode;

--- a/js/ConstantSourceNode.js
+++ b/js/ConstantSourceNode.js
@@ -119,7 +119,6 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'ConstantSourceNode',
     },
-
     offset: kEnumerableProperty,
 
   });

--- a/js/DelayNode.js
+++ b/js/DelayNode.js
@@ -124,7 +124,6 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'DelayNode',
     },
-
     delayTime: kEnumerableProperty,
 
   });

--- a/js/DynamicsCompressorNode.js
+++ b/js/DynamicsCompressorNode.js
@@ -196,13 +196,11 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'DynamicsCompressorNode',
     },
-
     threshold: kEnumerableProperty,
     knee: kEnumerableProperty,
     ratio: kEnumerableProperty,
     attack: kEnumerableProperty,
     release: kEnumerableProperty,
-
     reduction: kEnumerableProperty,
 
   });

--- a/js/GainNode.js
+++ b/js/GainNode.js
@@ -116,7 +116,6 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'GainNode',
     },
-
     gain: kEnumerableProperty,
 
   });

--- a/js/IIRFilterNode.js
+++ b/js/IIRFilterNode.js
@@ -107,7 +107,7 @@ module.exports = (jsExport, nativeBinding) => {
 
     }
 
-    getFrequencyResponse(...args) {
+    getFrequencyResponse(frequencyHz, magResponse, phaseResponse) {
       if (!(this instanceof IIRFilterNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'IIRFilterNode\'');
       }
@@ -116,8 +116,20 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'IIRFilterNode': 3 argument required, but only ${arguments.length} present`);
       }
 
+      if (!(frequencyHz instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'IIRFilterNode': Parameter 1 is not of type 'Float32Array'`);
+      }
+
+      if (!(magResponse instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'IIRFilterNode': Parameter 2 is not of type 'Float32Array'`);
+      }
+
+      if (!(phaseResponse instanceof Float32Array)) {
+        throw new TypeError(`Failed to execute 'getFrequencyResponse' on 'IIRFilterNode': Parameter 3 is not of type 'Float32Array'`);
+      }
+
       try {
-        return this[kNapiObj].getFrequencyResponse(...args);
+        return this[kNapiObj].getFrequencyResponse(frequencyHz, magResponse, phaseResponse);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -145,14 +157,6 @@ module.exports = (jsExport, nativeBinding) => {
     },
 
     getFrequencyResponse: kEnumerableProperty,
-  });
-
-  Object.defineProperty(IIRFilterNode.prototype.getFrequencyResponse, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 3,
   });
 
   return IIRFilterNode;

--- a/js/IIRFilterNode.js
+++ b/js/IIRFilterNode.js
@@ -66,7 +66,7 @@ module.exports = (jsExport, nativeBinding) => {
       }
 
       // required options
-      if (typeof options !== 'object' || (options && !('feedforward' in options))) {
+      if (typeof options !== 'object' || (options && options.feedforward === undefined)) {
         throw new TypeError('Failed to construct \'IIRFilterNode\': Failed to read the \'feedforward\'\' property from IIRFilterOptions: Required member is undefined');
       }
 
@@ -81,7 +81,7 @@ module.exports = (jsExport, nativeBinding) => {
       }
 
       // required options
-      if (typeof options !== 'object' || (options && !('feedback' in options))) {
+      if (typeof options !== 'object' || (options && options.feedback === undefined)) {
         throw new TypeError('Failed to construct \'IIRFilterNode\': Failed to read the \'feedback\'\' property from IIRFilterOptions: Required member is undefined');
       }
 

--- a/js/MediaStreamAudioSourceNode.js
+++ b/js/MediaStreamAudioSourceNode.js
@@ -66,7 +66,7 @@ module.exports = (jsExport, nativeBinding) => {
       }
 
       // required options
-      if (typeof options !== 'object' || (options && !('mediaStream' in options))) {
+      if (typeof options !== 'object' || (options && options.mediaStream === undefined)) {
         throw new TypeError('Failed to construct \'MediaStreamAudioSourceNode\': Failed to read the \'mediaStream\'\' property from MediaStreamAudioSourceOptions: Required member is undefined');
       }
 

--- a/js/OscillatorNode.js
+++ b/js/OscillatorNode.js
@@ -165,7 +165,7 @@ module.exports = (jsExport, nativeBinding) => {
       }
     }
 
-    setPeriodicWave(...args) {
+    setPeriodicWave(periodicWave) {
       if (!(this instanceof OscillatorNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'OscillatorNode\'');
       }
@@ -174,10 +174,14 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'setPeriodicWave' on 'OscillatorNode': 1 argument required, but only ${arguments.length} present`);
       }
 
-      args[0] = args[0][kNapiObj];
+      if (!(periodicWave instanceof jsExport.PeriodicWave)) {
+        throw new TypeError(`Failed to execute 'setPeriodicWave' on 'OscillatorNode': Parameter 1 is not of type 'PeriodicWave'`);
+      }
+
+      periodicWave = periodicWave[kNapiObj];
 
       try {
-        return this[kNapiObj].setPeriodicWave(...args);
+        return this[kNapiObj].setPeriodicWave(periodicWave);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -203,21 +207,10 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'OscillatorNode',
     },
-
     frequency: kEnumerableProperty,
     detune: kEnumerableProperty,
-
     type: kEnumerableProperty,
-
     setPeriodicWave: kEnumerableProperty,
-  });
-
-  Object.defineProperty(OscillatorNode.prototype.setPeriodicWave, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 1,
   });
 
   return OscillatorNode;

--- a/js/PannerNode.js
+++ b/js/PannerNode.js
@@ -414,7 +414,7 @@ module.exports = (jsExport, nativeBinding) => {
       }
     }
 
-    setPosition(...args) {
+    setPosition(x, y, z) {
       if (!(this instanceof PannerNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'PannerNode\'');
       }
@@ -423,14 +423,26 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'setPosition' on 'PannerNode': 3 argument required, but only ${arguments.length} present`);
       }
 
+      x = conversions['float'](x, {
+        context: `Failed to execute 'setPosition' on 'PannerNode': Parameter 1`,
+      });
+
+      y = conversions['float'](y, {
+        context: `Failed to execute 'setPosition' on 'PannerNode': Parameter 2`,
+      });
+
+      z = conversions['float'](z, {
+        context: `Failed to execute 'setPosition' on 'PannerNode': Parameter 3`,
+      });
+
       try {
-        return this[kNapiObj].setPosition(...args);
+        return this[kNapiObj].setPosition(x, y, z);
       } catch (err) {
         throwSanitizedError(err);
       }
     }
 
-    setOrientation(...args) {
+    setOrientation(x, y, z) {
       if (!(this instanceof PannerNode)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'PannerNode\'');
       }
@@ -439,8 +451,20 @@ module.exports = (jsExport, nativeBinding) => {
         throw new TypeError(`Failed to execute 'setOrientation' on 'PannerNode': 3 argument required, but only ${arguments.length} present`);
       }
 
+      x = conversions['float'](x, {
+        context: `Failed to execute 'setOrientation' on 'PannerNode': Parameter 1`,
+      });
+
+      y = conversions['float'](y, {
+        context: `Failed to execute 'setOrientation' on 'PannerNode': Parameter 2`,
+      });
+
+      z = conversions['float'](z, {
+        context: `Failed to execute 'setOrientation' on 'PannerNode': Parameter 3`,
+      });
+
       try {
-        return this[kNapiObj].setOrientation(...args);
+        return this[kNapiObj].setOrientation(x, y, z);
       } catch (err) {
         throwSanitizedError(err);
       }
@@ -466,14 +490,12 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'PannerNode',
     },
-
     positionX: kEnumerableProperty,
     positionY: kEnumerableProperty,
     positionZ: kEnumerableProperty,
     orientationX: kEnumerableProperty,
     orientationY: kEnumerableProperty,
     orientationZ: kEnumerableProperty,
-
     panningModel: kEnumerableProperty,
     distanceModel: kEnumerableProperty,
     refDistance: kEnumerableProperty,
@@ -482,25 +504,8 @@ module.exports = (jsExport, nativeBinding) => {
     coneInnerAngle: kEnumerableProperty,
     coneOuterAngle: kEnumerableProperty,
     coneOuterGain: kEnumerableProperty,
-
     setPosition: kEnumerableProperty,
     setOrientation: kEnumerableProperty,
-  });
-
-  Object.defineProperty(PannerNode.prototype.setPosition, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 3,
-  });
-
-  Object.defineProperty(PannerNode.prototype.setOrientation, 'length', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: 3,
   });
 
   return PannerNode;

--- a/js/StereoPannerNode.js
+++ b/js/StereoPannerNode.js
@@ -116,7 +116,6 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'StereoPannerNode',
     },
-
     pan: kEnumerableProperty,
 
   });

--- a/js/lib/errors.js
+++ b/js/lib/errors.js
@@ -111,15 +111,21 @@ exports.throwSanitizedError = function throwSanitizedError(err) {
     overrideStack(err, error);
 
     throw error;
-  } if (originalMessage.startsWith('IndexSizeError')) {
+  } else if (originalMessage.startsWith('IndexSizeError')) {
     const msg = originalMessage.replace(/^IndexSizeError - /, '');
     const error = new DOMException(msg, 'IndexSizeError');
     overrideStack(err, error);
 
     throw error;
-  } if (originalMessage.startsWith('InvalidAccessError')) {
+  } else if (originalMessage.startsWith('InvalidAccessError')) {
     const msg = originalMessage.replace(/^InvalidAccessError - /, '');
     const error = new DOMException(msg, 'InvalidAccessError');
+    overrideStack(err, error);
+
+    throw error;
+  } else if (originalMessage.startsWith('NotFoundError')) {
+    const msg = originalMessage.replace(/^NotFoundError - /, '');
+    const error = new DOMException(msg, 'NotFoundError');
     overrideStack(err, error);
 
     throw error;

--- a/js/lib/errors.js
+++ b/js/lib/errors.js
@@ -124,6 +124,6 @@ exports.throwSanitizedError = function throwSanitizedError(err) {
     throw error;
   }
 
-  console.warn('[lib/errors.js] Possibly unhandled error type', err.message);
+  console.warn('[lib/errors.js] Unexpected Rust error', err);
   throw err;
 }

--- a/js/lib/errors.js
+++ b/js/lib/errors.js
@@ -87,6 +87,7 @@ exports.throwSanitizedError = function throwSanitizedError(err) {
   if (originalMessage.startsWith('TypeError')) {
     const msg = originalMessage.replace(/^TypeError - /, '');
     const error = new TypeError(msg);
+    overrideStack(err, error);
 
     throw error;
   } else if (originalMessage.startsWith('RangeError')) {

--- a/src/audio_param.rs
+++ b/src/audio_param.rs
@@ -91,10 +91,7 @@ fn set_automation_rate(ctx: CallContext) -> Result<JsUndefined> {
     let value = match utf8_str.as_str() {
         "a-rate" => AutomationRate::A,
         "k-rate" => AutomationRate::K,
-        _ => panic!(
-            "The provided value '{:?}' is not a valid enum value of type AutomationRate.",
-            utf8_str
-        ),
+        _ => panic!("TypeError - The provided value '{:?}' is not a valid enum value of type AutomationRate.", utf8_str),
     };
     obj.set_automation_rate(value);
 


### PR DESCRIPTION
Almost got rid of the type error issues

#### before
```
RESULTS:
  - # pass: 6748
  - # fail: 791
  - # type error issues: 24
```

#### after
```
RESULTS:
  - # pass: 6813
  - # fail: 743
  - # type error issues: 5
```

Remaining one are linked to:
- the-mediastreamaudiodestinationnode-interface/ctor-mediastreamaudiodestination.html (not relevant for now, cf. #91)
- the-audionode-interface/audionode-disconnect.html (cf. https://github.com/orottier/web-audio-api-rs/issues/471)