### PR TITLE
Feat - some ScriptProcessorNode tail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 napi = {version="2.15", features=["napi9", "tokio_rt"]}
 napi-derive = "2.15"
 uuid = {version="1.6.1", features = ["v4", "fast-rng"]}
-web-audio-api = "1.0.0-rc.4"
-# web-audio-api = { path = "../web-audio-api-rs" }
+# web-audio-api = "1.0.0-rc.4"
+web-audio-api = { path = "../web-audio-api-rs" }
 
 [target.'cfg(all(any(windows, unix), target_arch = "x86_64", not(target_env = "musl")))'.dependencies]
 mimalloc = {version = "0.1"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = {version="2.15", features=["napi9", "tokio_rt"]}
 napi-derive = "2.15"
-uuid = {version="1.6.1", features = ["v4", "fast-rng"]}
 # web-audio-api = "1.0.0-rc.5"
 web-audio-api = { path = "../web-audio-api-rs" }
 

--- a/examples/script-processor.mjs
+++ b/examples/script-processor.mjs
@@ -5,7 +5,6 @@ const audioContext = new AudioContext({ latencyHint });
 
 const sine = new OscillatorNode(audioContext);
 sine.frequency.value = 200;
-sine.connect(audioContext.destination);
 sine.start();
 
 const scriptProcessor = new ScriptProcessorNode(audioContext);
@@ -14,5 +13,6 @@ scriptProcessor.addEventListener('audioprocess', e => {
   console.log(e.inputBuffer);
   console.log(e.outputBuffer);
 });
-scriptProcessor.connect(audioContext.destination);
+
+sine.connect(scriptProcessor).connect(audioContext.destination);
 

--- a/examples/script-processor.mjs
+++ b/examples/script-processor.mjs
@@ -1,0 +1,18 @@
+import { AudioContext, OscillatorNode, ScriptProcessorNode } from '../index.mjs';
+
+const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
+const audioContext = new AudioContext({ latencyHint });
+
+const sine = new OscillatorNode(audioContext);
+sine.frequency.value = 200;
+sine.connect(audioContext.destination);
+sine.start();
+
+const scriptProcessor = new ScriptProcessorNode(audioContext);
+scriptProcessor.addEventListener('audioprocess', e => {
+  console.log(e.playbackTime);
+  console.log(e.inputBuffer);
+  console.log(e.outputBuffer);
+});
+scriptProcessor.connect(audioContext.destination);
+

--- a/examples/script-processor.mjs
+++ b/examples/script-processor.mjs
@@ -1,5 +1,5 @@
-import { AudioContext, GainNode, OscillatorNode, ScriptProcessorNode } from '../index.mjs';
-import { kNapiObj } from '../js/lib/symbols.js'
+import { AudioContext, OscillatorNode, ScriptProcessorNode } from '../index.mjs';
+import { sleep } from '@ircam/sc-utils';
 
 const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
 const audioContext = new AudioContext({ latencyHint });
@@ -7,16 +7,15 @@ const audioContext = new AudioContext({ latencyHint });
 const sine = new OscillatorNode(audioContext);
 sine.frequency.value = 200;
 
-const scriptProcessor = new ScriptProcessorNode(audioContext);
-const buffer = new Float32Array(scriptProcessor.bufferSize);
-scriptProcessor.addEventListener('audioprocess', e => {
-  e.inputBuffer.copyFromChannel(buffer, 0);
-  // add noise
-  for (let i = 0; i < buffer.length; i++) {
-    buffer[i] += Math.random() * 2 - 1;
-  }
+const scriptProcessor = audioContext.createScriptProcessor();
 
-  e.outputBuffer.copyToChannel(buffer, 0);
+scriptProcessor.addEventListener('audioprocess', e => {
+  const input = e.inputBuffer.getChannelData(0);
+  const output = e.outputBuffer.getChannelData(0);
+
+  for (let i = 0; i < output.length; i++) {
+    output[i] = input[i] + Math.random() * 2 - 1;
+  }
 });
 
 sine

--- a/examples/script-processor.mjs
+++ b/examples/script-processor.mjs
@@ -1,4 +1,5 @@
-import { AudioContext, OscillatorNode, ScriptProcessorNode } from '../index.mjs';
+import { AudioContext, GainNode, OscillatorNode, ScriptProcessorNode } from '../index.mjs';
+import { kNapiObj } from '../js/lib/symbols.js'
 
 const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
 const audioContext = new AudioContext({ latencyHint });
@@ -7,12 +8,21 @@ const sine = new OscillatorNode(audioContext);
 sine.frequency.value = 200;
 sine.start();
 
+const gain = new GainNode(audioContext);
+
 const scriptProcessor = new ScriptProcessorNode(audioContext);
+const buffer = new Float32Array(scriptProcessor.bufferSize);
 scriptProcessor.addEventListener('audioprocess', e => {
-  console.log(e.playbackTime);
-  console.log(e.inputBuffer);
-  console.log(e.outputBuffer);
+  e.inputBuffer.copyFromChannel(buffer, 0);
+  // add noise
+  for (let i = 0; i < buffer.length; i++) {
+    buffer[i] += Math.random() * 2 - 1;
+  }
+
+  e.outputBuffer.copyToChannel(buffer, 0);
 });
 
-sine.connect(scriptProcessor).connect(audioContext.destination);
+sine
+  .connect(scriptProcessor)
+  .connect(audioContext.destination);
 

--- a/examples/script-processor.mjs
+++ b/examples/script-processor.mjs
@@ -6,9 +6,6 @@ const audioContext = new AudioContext({ latencyHint });
 
 const sine = new OscillatorNode(audioContext);
 sine.frequency.value = 200;
-sine.start();
-
-const gain = new GainNode(audioContext);
 
 const scriptProcessor = new ScriptProcessorNode(audioContext);
 const buffer = new Float32Array(scriptProcessor.bufferSize);
@@ -25,4 +22,6 @@ scriptProcessor.addEventListener('audioprocess', e => {
 sine
   .connect(scriptProcessor)
   .connect(audioContext.destination);
+
+sine.start();
 

--- a/generator/index.mjs
+++ b/generator/index.mjs
@@ -30,8 +30,11 @@ const generatedNodes = [
   `WaveShaperNode`,
 ];
 
-// list of supported nodes, for factory methods, etc.
-const audioNodes = [];
+// list of supported nodes. If present in this list the nodes themselves are not
+// generated but we still to add them automatically to e.g. factory methods, etc.
+let supportedNodes = [
+  'ScriptProcessorNode',
+];
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -192,13 +195,11 @@ const utils = {
   },
 };
 
+supportedNodes = supportedNodes.map(name => utils.findInTree(name));
+
 // For stats
 const parsed = new Set();
 const ignored = new Set();
-
-function findInTree(name) {
-  return tree.find(l => l.name === name);
-}
 
 console.log('-------------------------------------------------------------');
 console.log('## Generate rs files');
@@ -208,7 +209,7 @@ let rsTemplates = path.join(__dirname, 'rs');
 let rsOutput = path.join(process.cwd(), 'src');
 
 generatedNodes.sort().forEach((name, index) => {
-  const nodeIdl = findInTree(name);
+  const nodeIdl = utils.findInTree(name);
   const input = path.join(rsTemplates, `audio_nodes.tmpl.rs`);
   const output = path.join(rsOutput, `${utils.slug(nodeIdl)}.rs`);
 
@@ -220,7 +221,7 @@ generatedNodes.sort().forEach((name, index) => {
 
   fs.writeFileSync(output, generatedPrefix(code));
   // add to the list of supported nodes
-  audioNodes.push(nodeIdl);
+  supportedNodes.push(nodeIdl);
 });
 
 // Generate files that require the list of generated AudioNode
@@ -232,7 +233,7 @@ generatedNodes.sort().forEach((name, index) => {
 
   const codeTmpl = fs.readFileSync(input, 'utf8');
   const tmpl = compile(codeTmpl);
-  const code = tmpl({ nodes: audioNodes, tree, ...utils });
+  const code = tmpl({ nodes: supportedNodes, tree, ...utils });
 
   fs.writeFileSync(output, generatedPrefix(code));
 });
@@ -291,13 +292,13 @@ async function beautifyAndLint(pathname, code) {
 
   const codeTmpl = fs.readFileSync(input, 'utf8');
   const tmpl = compile(codeTmpl);
-  const code = tmpl({ nodes: audioNodes, ...utils });
+  const code = tmpl({ nodes: supportedNodes, ...utils });
 
   beautifyAndLint(output, generatedPrefix(code));
 });
 
 ['AudioParam', 'AudioNode'].concat(generatedNodes).forEach(src => {
-  const nodeIdl = findInTree(src);
+  const nodeIdl = utils.findInTree(src);
   let input;
 
   if (['AudioParam', 'AudioNode'].includes(src)) {

--- a/generator/rs/audio_nodes.tmpl.rs
+++ b/generator/rs/audio_nodes.tmpl.rs
@@ -431,7 +431,7 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
             let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
-            node.set_onended(move |e| {
+            node.set_onended(move |e: Event| {
                 let event = WebAudioEventType::from(e);
                 tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
                 napi_context.tsfn_store().delete(store_id);

--- a/generator/rs/lib.tmpl.rs
+++ b/generator/rs/lib.tmpl.rs
@@ -49,7 +49,7 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[module_exports]
 fn init(mut exports: JsObject, env: Env) -> Result<()> {
     // Do not print panic messages, handle through JS errors
-    std::panic::set_hook(Box::new(|_panic_info| {}));
+    // std::panic::set_hook(Box::new(|_panic_info| {}));
 
     let napi_class = NapiAudioContext::create_js_class(&env)?;
     exports.set_named_property("AudioContext", napi_class)?;

--- a/generator/rs/lib.tmpl.rs
+++ b/generator/rs/lib.tmpl.rs
@@ -3,13 +3,7 @@
 use napi::{Env, JsObject, Result};
 use napi_derive::module_exports;
 
-// cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
-#[allow(clippy::needless_lifetimes)]
-pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {
-    unsafe {
-        std::slice::from_raw_parts(floats.as_ptr() as *const _, floats.len() * 4)
-    }
-}
+mod utils;
 
 #[macro_use]
 mod base_audio_context;

--- a/index.mjs
+++ b/index.mjs
@@ -40,6 +40,7 @@ export const {
   PeriodicWave,
   AudioBuffer,
   // generated supported nodes
+  ScriptProcessorNode,
   AnalyserNode,
   AudioBufferSourceNode,
   BiquadFilterNode,

--- a/js/BaseAudioContext.js
+++ b/js/BaseAudioContext.js
@@ -210,6 +210,20 @@ module.exports = (jsExport, _nativeBinding) => {
     // --------------------------------------------------------------------
     // Factory Methods (use the patched AudioNodes)
     // --------------------------------------------------------------------
+    createScriptProcessor(bufferSize = 0, numberOfInputChannels = 2, numberOfOutputChannels = 2) {
+      if (!(this instanceof BaseAudioContext)) {
+        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
+      }
+
+      const options = {
+        bufferSize,
+        numberOfInputChannels,
+        numberOfOutputChannels,
+      };
+
+      return new jsExport.ScriptProcessorNode(this, options);
+    }
+
     createAnalyser() {
       if (!(this instanceof BaseAudioContext)) {
         throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'BaseAudioContext\'');
@@ -389,6 +403,7 @@ module.exports = (jsExport, _nativeBinding) => {
       configurable: true,
       value: 'BaseAudioContext',
     },
+    createScriptProcessor: kEnumerableProperty,
     createAnalyser: kEnumerableProperty,
     createBufferSource: kEnumerableProperty,
     createBiquadFilter: kEnumerableProperty,

--- a/js/ScriptProcessorNode.js
+++ b/js/ScriptProcessorNode.js
@@ -92,7 +92,9 @@ module.exports = (jsExport, nativeBinding) => {
         [kNapiObj]: napiObj,
       });
 
-      bridgeEventTarget(this);
+      bridgeEventTarget(this, {
+        AudioBuffer: jsExport.AudioBuffer,
+      });
     }
 
     get bufferSize() {
@@ -104,16 +106,16 @@ module.exports = (jsExport, nativeBinding) => {
     }
 
     get onaudioprocess() {
-      if (!(this instanceof AudioScheduledSourceNode)) {
-        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioScheduledSourceNode\'');
+      if (!(this instanceof ScriptProcessorNode)) {
+        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'ScriptProcessorNode\'');
       }
 
       return this.#onaudioprocess;
     }
 
     set onaudioprocess(value) {
-      if (!(this instanceof AudioScheduledSourceNode)) {
-        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioScheduledSourceNode\'');
+      if (!(this instanceof ScriptProcessorNode)) {
+        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'ScriptProcessorNode\'');
       }
 
       if (isFunction(value) || value === null) {

--- a/js/ScriptProcessorNode.js
+++ b/js/ScriptProcessorNode.js
@@ -49,8 +49,9 @@ module.exports = (jsExport, nativeBinding) => {
       // createScriptProcessor(bufferSize = 256, numberOfInputChannels = 2, numberOfOutputChannels = 2)
       // all unsigned long, all optional
       parsedOptions.bufferSize = 256;
-      parsedOptions.numberOfInputChannels = 2;
-      parsedOptions.numberOfOutputChannels = 2;
+      parsedOptions.numberOfInputChannels = 1;
+      // @note - this crashes when set to 2
+      parsedOptions.numberOfOutputChannels = 1;
       //
       // if (options && options.gain !== undefined) {
       //   parsedOptions.gain = conversions['float'](options.gain, {

--- a/js/ScriptProcessorNode.js
+++ b/js/ScriptProcessorNode.js
@@ -1,0 +1,148 @@
+/* eslint-disable no-unused-vars */
+const conversions = require('webidl-conversions');
+const {
+  toSanitizedSequence,
+} = require('./lib/cast.js');
+const {
+  isFunction,
+  kEnumerableProperty,
+} = require('./lib/utils.js');
+const {
+  throwSanitizedError,
+} = require('./lib/errors.js');
+const {
+  kNapiObj,
+  kAudioBuffer,
+} = require('./lib/symbols.js');
+const {
+  bridgeEventTarget,
+} = require('./lib/events.js');
+/* eslint-enable no-unused-vars */
+
+const AudioNode = require('./AudioNode.js');
+
+module.exports = (jsExport, nativeBinding) => {
+  class ScriptProcessorNode extends AudioNode {
+
+    #onaudioprocess = null;
+
+    constructor(context, options) {
+
+      if (arguments.length < 1) {
+        throw new TypeError(`Failed to construct 'ScriptProcessorNode': 1 argument required, but only ${arguments.length} present`);
+      }
+
+      if (!(context instanceof jsExport.BaseAudioContext)) {
+        throw new TypeError(`Failed to construct 'ScriptProcessorNode': argument 1 is not of type BaseAudioContext`);
+      }
+
+      // parsed version of the option to be passed to NAPI
+      const parsedOptions = {
+
+      };
+
+      if (options && typeof options !== 'object') {
+        throw new TypeError('Failed to construct \'ScriptProcessorNode\': argument 2 is not of type \'GainOptions\'');
+      }
+
+      // @todo
+      // createScriptProcessor(bufferSize = 256, numberOfInputChannels = 2, numberOfOutputChannels = 2)
+      // all unsigned long, all optional
+      parsedOptions.bufferSize = 256;
+      parsedOptions.numberOfInputChannels = 2;
+      parsedOptions.numberOfOutputChannels = 2;
+      //
+      // if (options && options.gain !== undefined) {
+      //   parsedOptions.gain = conversions['float'](options.gain, {
+      //     context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'gain' property from GainOptions: The provided value (${options.gain}})`,
+      //   });
+      // } else {
+      //   parsedOptions.gain = 1.0;
+      // }
+
+      if (options && options.channelCount !== undefined) {
+        parsedOptions.channelCount = conversions['unsigned long'](options.channelCount, {
+          enforceRange: true,
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelCount' property from GainOptions: The provided value '${options.channelCount}'`,
+        });
+      }
+
+      if (options && options.channelCountMode !== undefined) {
+        parsedOptions.channelCountMode = conversions['DOMString'](options.channelCountMode, {
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelCount' property from GainOptions: The provided value '${options.channelCountMode}'`,
+        });
+      }
+
+      if (options && options.channelInterpretation !== undefined) {
+        parsedOptions.channelInterpretation = conversions['DOMString'](options.channelInterpretation, {
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelInterpretation' property from GainOptions: The provided value '${options.channelInterpretation}'`,
+        });
+      }
+
+      let napiObj;
+
+      try {
+        napiObj = new nativeBinding.ScriptProcessorNode(context[kNapiObj], parsedOptions);
+      } catch (err) {
+        throwSanitizedError(err);
+      }
+
+      super(context, {
+        [kNapiObj]: napiObj,
+      });
+
+      bridgeEventTarget(this);
+    }
+
+    get bufferSize() {
+      if (!(this instanceof ScriptProcessorNode)) {
+        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'ScriptProcessorNode\'');
+      }
+
+      return this[kNapiObj].bufferSize;
+    }
+
+    get onaudioprocess() {
+      if (!(this instanceof AudioScheduledSourceNode)) {
+        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioScheduledSourceNode\'');
+      }
+
+      return this.#onaudioprocess;
+    }
+
+    set onaudioprocess(value) {
+      if (!(this instanceof AudioScheduledSourceNode)) {
+        throw new TypeError('Invalid Invocation: Value of \'this\' must be of type \'AudioScheduledSourceNode\'');
+      }
+
+      if (isFunction(value) || value === null) {
+        this.#onaudioprocess = value;
+      }
+    }
+
+  }
+
+  Object.defineProperties(ScriptProcessorNode, {
+    length: {
+      __proto__: null,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+      value: 1,
+    },
+  });
+
+  Object.defineProperties(ScriptProcessorNode.prototype, {
+    [Symbol.toStringTag]: {
+      __proto__: null,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+      value: 'ScriptProcessorNode',
+    },
+    gain: kEnumerableProperty,
+
+  });
+
+  return ScriptProcessorNode;
+};

--- a/js/ScriptProcessorNode.js
+++ b/js/ScriptProcessorNode.js
@@ -37,46 +37,60 @@ module.exports = (jsExport, nativeBinding) => {
       }
 
       // parsed version of the option to be passed to NAPI
-      const parsedOptions = {
-
-      };
+      const parsedOptions = {};
 
       if (options && typeof options !== 'object') {
-        throw new TypeError('Failed to construct \'ScriptProcessorNode\': argument 2 is not of type \'GainOptions\'');
+        throw new TypeError('Failed to construct \'ScriptProcessorNode\': argument 2 is not of type \'ScriptProcessorNodeOptions\'');
       }
 
-      // @todo
-      // createScriptProcessor(bufferSize = 256, numberOfInputChannels = 2, numberOfOutputChannels = 2)
-      // all unsigned long, all optional
-      parsedOptions.bufferSize = 256;
-      parsedOptions.numberOfInputChannels = 1;
-      // @note - this crashes when set to 2
-      parsedOptions.numberOfOutputChannels = 1;
-      //
-      // if (options && options.gain !== undefined) {
-      //   parsedOptions.gain = conversions['float'](options.gain, {
-      //     context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'gain' property from GainOptions: The provided value (${options.gain}})`,
-      //   });
-      // } else {
-      //   parsedOptions.gain = 1.0;
-      // }
+      // IDL defines bufferSize default value as 0
+      // cf. https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor
+      // > If it’s not passed in, or if the value is 0, then the implementation
+      // > will choose the best buffer size for the given environment, which will
+      // > be constant power of 2 throughout the lifetime of the node.
+      if (options && options.bufferSize !== undefined && options.bufferSize !== 0) {
+        parsedOptions.bufferSize = conversions['unsigned long'](options.bufferSize, {
+          enforceRange: true,
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'bufferSize' property from ScriptProcessorNodeOptions: The provided value '${options.bufferSize}'`,
+        });
+      } else {
+        parsedOptions.bufferSize = 256;
+      }
+
+      if (options && options.numberOfInputChannels !== undefined) {
+        parsedOptions.numberOfInputChannels = conversions['unsigned long'](options.numberOfInputChannels, {
+          enforceRange: true,
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'numberOfInputChannels' property from ScriptProcessorNodeOptions: The provided value '${options.numberOfInputChannels}'`,
+        });
+      } else {
+        parsedOptions.numberOfInputChannels = 2;
+      }
+
+      if (options && options.numberOfOutputChannels !== undefined) {
+        parsedOptions.numberOfOutputChannels = conversions['unsigned long'](options.numberOfOutputChannels, {
+          enforceRange: true,
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'numberOfOutputChannels' property from ScriptProcessorNodeOptions: The provided value '${options.numberOfOutputChannels}'`,
+        });
+      } else {
+        parsedOptions.numberOfOutputChannels = 2;
+      }
 
       if (options && options.channelCount !== undefined) {
         parsedOptions.channelCount = conversions['unsigned long'](options.channelCount, {
           enforceRange: true,
-          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelCount' property from GainOptions: The provided value '${options.channelCount}'`,
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelCount' property from ScriptProcessorNodeOptions: The provided value '${options.channelCount}'`,
         });
       }
 
       if (options && options.channelCountMode !== undefined) {
         parsedOptions.channelCountMode = conversions['DOMString'](options.channelCountMode, {
-          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelCount' property from GainOptions: The provided value '${options.channelCountMode}'`,
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelCount' property from ScriptProcessorNodeOptions: The provided value '${options.channelCountMode}'`,
         });
       }
 
       if (options && options.channelInterpretation !== undefined) {
         parsedOptions.channelInterpretation = conversions['DOMString'](options.channelInterpretation, {
-          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelInterpretation' property from GainOptions: The provided value '${options.channelInterpretation}'`,
+          context: `Failed to construct 'ScriptProcessorNode': Failed to read the 'channelInterpretation' property from ScriptProcessorNodeOptions: The provided value '${options.channelInterpretation}'`,
         });
       }
 
@@ -92,9 +106,7 @@ module.exports = (jsExport, nativeBinding) => {
         [kNapiObj]: napiObj,
       });
 
-      bridgeEventTarget(this, {
-        AudioBuffer: jsExport.AudioBuffer,
-      });
+      bridgeEventTarget(this, jsExport);
     }
 
     get bufferSize() {
@@ -131,7 +143,7 @@ module.exports = (jsExport, nativeBinding) => {
       writable: false,
       enumerable: false,
       configurable: true,
-      value: 1,
+      value: 0,
     },
   });
 
@@ -143,7 +155,8 @@ module.exports = (jsExport, nativeBinding) => {
       configurable: true,
       value: 'ScriptProcessorNode',
     },
-    gain: kEnumerableProperty,
+    bufferSize: kEnumerableProperty,
+    onaudioprocess: kEnumerableProperty,
 
   });
 

--- a/js/lib/events.js
+++ b/js/lib/events.js
@@ -7,6 +7,13 @@ const { isFunction } = require('./utils.js');
 module.exports.bridgeEventTarget = function bridgeEventTarget(jsObj) {
     // Finalize event registration on Rust side
   jsObj[kNapiObj][kDispatchEvent] = (err, eventType) => {
+    if (err) {
+      console.log(err);
+      return;
+    }
+
+    console.log(eventType);
+
     const event = new Event(eventType);
     // call attribute first if exists
     if (isFunction(jsObj[`on${event.type}`])) {

--- a/js/lib/events.js
+++ b/js/lib/events.js
@@ -17,8 +17,13 @@ module.exports.bridgeEventTarget = function bridgeEventTarget(jsObj, payload) {
 
     if (eventType === 'audioprocess') {
       event.playbackTime = eventOrType.playbackTime;
-      event.inputBuffer = new payload.AudioBuffer(eventOrType.inputBuffer);
-      event.outputBuffer = new payload.AudioBuffer(eventOrType.outputBuffer);
+
+      event.inputBuffer = new payload.AudioBuffer({
+        [kNapiObj]: eventOrType.inputBuffer
+      });
+      event.outputBuffer = new payload.AudioBuffer({
+        [kNapiObj]: eventOrType.outputBuffer
+      });
     }
     // call attribute first if exists
     if (isFunction(jsObj[`on${eventType}`])) {

--- a/js/monkey-patch.js
+++ b/js/monkey-patch.js
@@ -26,6 +26,7 @@ module.exports = function monkeyPatch(nativeBinding) {
   jsExport.AudioContext = require('./AudioContext.js')(jsExport, nativeBinding);
   jsExport.OfflineAudioContext = require('./OfflineAudioContext.js')(jsExport, nativeBinding);
 
+  jsExport.ScriptProcessorNode = require('./ScriptProcessorNode.js')(jsExport, nativeBinding);
   jsExport.AnalyserNode = require('./AnalyserNode.js')(jsExport, nativeBinding);
   jsExport.AudioBufferSourceNode = require('./AudioBufferSourceNode.js')(jsExport, nativeBinding);
   jsExport.BiquadFilterNode = require('./BiquadFilterNode.js')(jsExport, nativeBinding);

--- a/src/analyser_node.rs
+++ b/src/analyser_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiAnalyserNode(AnalyserNode);
 

--- a/src/audio_buffer.rs
+++ b/src/audio_buffer.rs
@@ -152,10 +152,6 @@ fn copy_to_channel(ctx: CallContext) -> Result<JsUndefined> {
 
     obj.copy_to_channel_with_offset(source, channel_number, offset);
 
-    let mut test = [0.; 10];
-    obj.copy_from_channel(&mut test, 0);
-    println!("1. inside copy to channel ({:?}): {:?}", &obj, test);
-
     ctx.env.get_undefined()
 }
 

--- a/src/audio_buffer.rs
+++ b/src/audio_buffer.rs
@@ -38,8 +38,15 @@ impl NapiAudioBuffer {
         }
     }
 
+    // @todo - rename to `insert`
     pub fn populate(&mut self, audio_buffer: AudioBuffer) {
         self.0 = Some(audio_buffer);
+    }
+
+    pub fn take(&mut self) -> AudioBuffer {
+        self.0
+            .take()
+            .expect("Invalid AudioBuffer.take() call, should be populated")
     }
 }
 
@@ -144,6 +151,10 @@ fn copy_to_channel(ctx: CallContext) -> Result<JsUndefined> {
     let offset = ctx.get::<JsNumber>(2)?.get_double()? as usize;
 
     obj.copy_to_channel_with_offset(source, channel_number, offset);
+
+    let mut test = [0.; 10];
+    obj.copy_from_channel(&mut test, 0);
+    println!("1. inside copy to channel ({:?}): {:?}", &obj, test);
 
     ctx.env.get_undefined()
 }

--- a/src/audio_buffer.rs
+++ b/src/audio_buffer.rs
@@ -50,11 +50,6 @@ impl NapiAudioBuffer {
     }
 }
 
-// dictionary AudioBufferOptions {
-//   unsigned long numberOfChannels = 1;
-//   required unsigned long length;
-//   required float sampleRate;
-// };
 #[js_function(1)]
 fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
@@ -65,6 +60,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
         // Internal caller
         // - BaseAudioContext::decodeAudioData
         // - OfflineAudioContext::startRendering
+        // - AudioProcessingEvent::{inputBuffer, outputBuffer}
         let napi_node = NapiAudioBuffer(None);
         ctx.env.wrap(&mut js_this, napi_node)?;
     } else {

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiAudioBufferSourceNode(AudioBufferSourceNode);
 
@@ -234,6 +235,7 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
 // ----------------------------------------------------
 #[js_function]
 fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
+    use crate::utils::WebAudioEventType;
     use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
     use web_audio_api::Event;
 
@@ -254,34 +256,39 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
         .unwrap();
     let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
 
-    let tsfn =
-        ctx.env
-            .create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-                let event_type = ctx.env.create_string(ctx.value.type_)?;
-                Ok(vec![event_type])
-            })?;
+    let tsfn = ctx.env.create_threadsafe_function(
+        &js_func,
+        0,
+        |ctx: ThreadSafeCallContext<WebAudioEventType>| {
+            let native_event = ctx.value.unwrap_event();
+            let event_type = ctx.env.create_string(native_event.type_)?;
+            Ok(vec![event_type])
+        },
+    )?;
 
     match audio_context_str {
         "AudioContext" => {
             let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
+            let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
             node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
+                let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+                napi_context.tsfn_store().delete(store_id);
             });
         }
         "OfflineAudioContext" => {
             let napi_context = ctx
                 .env
                 .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
+            let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
+            node.set_onended(move |e: Event| {
+                let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+                napi_context.tsfn_store().delete(store_id);
             });
         }
         &_ => unreachable!(),

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -272,7 +272,7 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
             let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
-            node.set_onended(move |e| {
+            node.set_onended(move |e: Event| {
                 let event = WebAudioEventType::from(e);
                 tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
                 napi_context.tsfn_store().delete(store_id);

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -1,16 +1,13 @@
-use std::collections::HashMap;
 use std::io::Cursor;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use napi::threadsafe_function::{
-    ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
-};
+use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
 use napi::*;
 use napi_derive::js_function;
-use uuid::Uuid;
 use web_audio_api::context::*;
 use web_audio_api::Event;
 
+use crate::utils::{TsfnStore, WebAudioEventType};
 use crate::*;
 
 #[derive(Clone)]
@@ -18,7 +15,7 @@ pub(crate) struct NapiAudioContext {
     context: Arc<AudioContext>,
     // store all ThreadsafeFunction created for listening to events
     // so that they can be aborted when the context is closed
-    tsfn_store: Arc<Mutex<HashMap<String, ThreadsafeFunction<Event>>>>,
+    tsfn_store: TsfnStore,
 }
 
 // for debug purpose
@@ -49,33 +46,8 @@ impl NapiAudioContext {
         &self.context
     }
 
-    pub fn store_thread_safe_listener(&self, tsfn: ThreadsafeFunction<Event>) -> String {
-        let mut tsfn_store = self.tsfn_store.lock().unwrap();
-        let uuid = Uuid::new_v4();
-        tsfn_store.insert(uuid.to_string(), tsfn);
-
-        uuid.to_string()
-    }
-
-    // We need to clean things around so that the js object can be garbage collected.
-    // But we also need to wait so that the previous tsfn.call is executed.
-    // This is not clean, but don't see how to implement that properly right now.
-    pub fn clear_thread_safe_listener(&self, store_id: String) {
-        std::thread::sleep(std::time::Duration::from_millis(1));
-        let mut tsfn_store = self.tsfn_store.lock().unwrap();
-
-        if let Some(tsfn) = tsfn_store.remove(&store_id) {
-            let _ = tsfn.abort();
-        }
-    }
-
-    pub fn clear_all_thread_safe_listeners(&self) {
-        std::thread::sleep(std::time::Duration::from_millis(1));
-        let mut tsfn_store = self.tsfn_store.lock().unwrap();
-
-        for (_, tsfn) in tsfn_store.drain() {
-            let _ = tsfn.abort();
-        }
+    pub fn tsfn_store(&self) -> TsfnStore {
+        self.tsfn_store.clone()
     }
 }
 
@@ -137,7 +109,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     // -------------------------------------------------
     let napi_audio_context = NapiAudioContext {
         context: Arc::new(audio_context),
-        tsfn_store: Arc::new(HashMap::new().into()),
+        tsfn_store: TsfnStore::new(),
     };
     ctx.env.wrap(&mut js_this, napi_audio_context)?;
 
@@ -267,24 +239,28 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
         .unwrap();
     let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
 
-    let tsfn =
-        ctx.env
-            .create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-                let event_type = ctx.env.create_string(ctx.value.type_)?;
-                Ok(vec![event_type])
-            })?;
+    let tsfn = ctx.env.create_threadsafe_function(
+        &js_func,
+        0,
+        |ctx: ThreadSafeCallContext<WebAudioEventType>| {
+            let native_event = ctx.value.unwrap_event();
+            let event_type = ctx.env.create_string(native_event.type_)?;
+            Ok(vec![event_type])
+        },
+    )?;
 
-    let _ = napi_context.store_thread_safe_listener(tsfn.clone());
+    let _ = napi_context.tsfn_store().add(tsfn.clone());
 
     {
         let tsfn = tsfn.clone();
         let napi_context = napi_context.clone();
 
-        context.set_onstatechange(move |e| {
-            tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+        context.set_onstatechange(move |e: Event| {
+            let event = WebAudioEventType::from(e);
+            tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
 
             if napi_context.unwrap().state() == AudioContextState::Closed {
-                napi_context.clear_all_thread_safe_listeners();
+                napi_context.tsfn_store().clear();
             }
         });
     }
@@ -292,8 +268,9 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
     {
         let tsfn = tsfn.clone();
 
-        context.set_onsinkchange(move |e| {
-            tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+        context.set_onsinkchange(move |e: Event| {
+            let event = WebAudioEventType::from(e);
+            tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
         });
     }
 

--- a/src/audio_node.rs
+++ b/src/audio_node.rs
@@ -206,6 +206,15 @@ macro_rules! audio_node_impl {
 
                     Ok(js_dest)
                 }
+                "ScriptProcessorNode" => {
+                    let napi_dest = ctx
+                        .env
+                        .unwrap::<$crate::script_processor_node::NapiScriptProcessorNode>(&js_dest)?;
+                    let native_dest = napi_dest.unwrap();
+                    let _res = native_src.connect_at(native_dest, output as usize, input as usize);
+
+                    Ok(js_dest)
+                }
                 "AnalyserNode" => {
                     let napi_dest = ctx
                         .env
@@ -399,6 +408,13 @@ macro_rules! audio_node_impl {
                                 .unwrap::<$crate::audio_destination_node::NapiAudioDestinationNode>(
                                 &js_dest,
                             )?;
+                            let native_dest = napi_dest.unwrap();
+                            native_src.disconnect_from(native_dest);
+                        }
+                        "ScriptProcessorNode" => {
+                            let napi_dest = ctx
+                                .env
+                                .unwrap::<$crate::script_processor_node::NapiScriptProcessorNode>(&js_dest)?;
                             let native_dest = napi_dest.unwrap();
                             native_src.disconnect_from(native_dest);
                         }

--- a/src/biquad_filter_node.rs
+++ b/src/biquad_filter_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiBiquadFilterNode(BiquadFilterNode);
 

--- a/src/channel_merger_node.rs
+++ b/src/channel_merger_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiChannelMergerNode(ChannelMergerNode);
 

--- a/src/channel_splitter_node.rs
+++ b/src/channel_splitter_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiChannelSplitterNode(ChannelSplitterNode);
 

--- a/src/constant_source_node.rs
+++ b/src/constant_source_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiConstantSourceNode(ConstantSourceNode);
 
@@ -162,6 +163,7 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
 // ----------------------------------------------------
 #[js_function]
 fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
+    use crate::utils::WebAudioEventType;
     use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
     use web_audio_api::Event;
 
@@ -182,34 +184,39 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
         .unwrap();
     let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
 
-    let tsfn =
-        ctx.env
-            .create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-                let event_type = ctx.env.create_string(ctx.value.type_)?;
-                Ok(vec![event_type])
-            })?;
+    let tsfn = ctx.env.create_threadsafe_function(
+        &js_func,
+        0,
+        |ctx: ThreadSafeCallContext<WebAudioEventType>| {
+            let native_event = ctx.value.unwrap_event();
+            let event_type = ctx.env.create_string(native_event.type_)?;
+            Ok(vec![event_type])
+        },
+    )?;
 
     match audio_context_str {
         "AudioContext" => {
             let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
+            let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
             node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
+                let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+                napi_context.tsfn_store().delete(store_id);
             });
         }
         "OfflineAudioContext" => {
             let napi_context = ctx
                 .env
                 .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
+            let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
+            node.set_onended(move |e: Event| {
+                let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+                napi_context.tsfn_store().delete(store_id);
             });
         }
         &_ => unreachable!(),

--- a/src/constant_source_node.rs
+++ b/src/constant_source_node.rs
@@ -200,7 +200,7 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
             let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
-            node.set_onended(move |e| {
+            node.set_onended(move |e: Event| {
                 let event = WebAudioEventType::from(e);
                 tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
                 napi_context.tsfn_store().delete(store_id);

--- a/src/convolver_node.rs
+++ b/src/convolver_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiConvolverNode(ConvolverNode);
 

--- a/src/delay_node.rs
+++ b/src/delay_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiDelayNode(DelayNode);
 

--- a/src/dynamics_compressor_node.rs
+++ b/src/dynamics_compressor_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiDynamicsCompressorNode(DynamicsCompressorNode);
 

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiGainNode(GainNode);
 

--- a/src/iir_filter_node.rs
+++ b/src/iir_filter_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiIIRFilterNode(IIRFilterNode);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ mod offline_audio_context;
 use crate::offline_audio_context::NapiOfflineAudioContext;
 // Generated audio nodes
 
+mod script_processor_node;
+use crate::script_processor_node::NapiScriptProcessorNode;
 mod analyser_node;
 use crate::analyser_node::NapiAnalyserNode;
 mod audio_buffer_source_node;
@@ -118,6 +120,9 @@ fn init(mut exports: JsObject, env: Env) -> Result<()> {
     // ----------------------------------------------------------------
     // Generated audio nodes
     // ----------------------------------------------------------------
+
+    let napi_class = NapiScriptProcessorNode::create_js_class(&env)?;
+    exports.set_named_property("ScriptProcessorNode", napi_class)?;
 
     let napi_class = NapiAnalyserNode::create_js_class(&env)?;
     exports.set_named_property("AnalyserNode", napi_class)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,7 @@
 use napi::{Env, JsObject, Result};
 use napi_derive::module_exports;
 
-// cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
-#[allow(clippy::needless_lifetimes)]
-pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {
-    unsafe { std::slice::from_raw_parts(floats.as_ptr() as *const _, floats.len() * 4) }
-}
+mod utils;
 
 #[macro_use]
 mod base_audio_context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[module_exports]
 fn init(mut exports: JsObject, env: Env) -> Result<()> {
     // Do not print panic messages, handle through JS errors
-    std::panic::set_hook(Box::new(|_panic_info| {}));
+    // std::panic::set_hook(Box::new(|_panic_info| {}));
 
     let napi_class = NapiAudioContext::create_js_class(&env)?;
     exports.set_named_property("AudioContext", napi_class)?;

--- a/src/media_stream_audio_source_node.rs
+++ b/src/media_stream_audio_source_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiMediaStreamAudioSourceNode(MediaStreamAudioSourceNode);
 

--- a/src/oscillator_node.rs
+++ b/src/oscillator_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiOscillatorNode(OscillatorNode);
 
@@ -259,6 +260,7 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
 // ----------------------------------------------------
 #[js_function]
 fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
+    use crate::utils::WebAudioEventType;
     use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
     use web_audio_api::Event;
 
@@ -279,34 +281,39 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
         .unwrap();
     let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
 
-    let tsfn =
-        ctx.env
-            .create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-                let event_type = ctx.env.create_string(ctx.value.type_)?;
-                Ok(vec![event_type])
-            })?;
+    let tsfn = ctx.env.create_threadsafe_function(
+        &js_func,
+        0,
+        |ctx: ThreadSafeCallContext<WebAudioEventType>| {
+            let native_event = ctx.value.unwrap_event();
+            let event_type = ctx.env.create_string(native_event.type_)?;
+            Ok(vec![event_type])
+        },
+    )?;
 
     match audio_context_str {
         "AudioContext" => {
             let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
+            let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
             node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
+                let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+                napi_context.tsfn_store().delete(store_id);
             });
         }
         "OfflineAudioContext" => {
             let napi_context = ctx
                 .env
                 .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
+            let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
+            node.set_onended(move |e: Event| {
+                let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+                napi_context.tsfn_store().delete(store_id);
             });
         }
         &_ => unreachable!(),

--- a/src/oscillator_node.rs
+++ b/src/oscillator_node.rs
@@ -297,7 +297,7 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
             let store_id = napi_context.tsfn_store().add(tsfn.clone());
             let napi_context = napi_context.clone();
 
-            node.set_onended(move |e| {
+            node.set_onended(move |e: Event| {
                 let event = WebAudioEventType::from(e);
                 tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
                 napi_context.tsfn_store().delete(store_id);

--- a/src/panner_node.rs
+++ b/src/panner_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiPannerNode(PannerNode);
 

--- a/src/script_processor_node.rs
+++ b/src/script_processor_node.rs
@@ -1,0 +1,190 @@
+use crate::*;
+use napi::*;
+use napi_derive::js_function;
+use web_audio_api::node::*;
+
+pub(crate) struct NapiScriptProcessorNode(ScriptProcessorNode);
+
+impl NapiScriptProcessorNode {
+    pub fn create_js_class(env: &Env) -> Result<JsFunction> {
+        let interface = audio_node_interface![
+            Property::new("bufferSize")?.with_getter(get_buffer_size),
+            Property::new("__initEventTarget__")?.with_method(init_event_target)
+        ];
+
+        env.define_class("ScriptProcessorNode", constructor, &interface)
+    }
+
+    pub fn unwrap(&self) -> &ScriptProcessorNode {
+        &self.0
+    }
+}
+
+#[js_function(1)]
+fn constructor(ctx: CallContext) -> Result<JsUndefined> {
+    let mut js_this = ctx.this_unchecked::<JsObject>();
+
+    let js_audio_context = ctx.get::<JsObject>(0)?;
+
+    // --------------------------------------------------------
+    // Parse ScriptProcessorOptions
+    // by bindings construction all fields are populated on the JS side
+    // --------------------------------------------------------
+    let js_options = ctx.get::<JsObject>(1)?;
+
+    let buffer_size = js_options
+        .get::<&str, JsNumber>("bufferSize")?
+        .unwrap()
+        .get_double()? as usize;
+
+    let number_of_input_channels = js_options
+        .get::<&str, JsNumber>("numberOfInputChannels")?
+        .unwrap()
+        .get_double()? as usize;
+
+    let number_of_output_channels = js_options
+        .get::<&str, JsNumber>("numberOfOutputChannels")?
+        .unwrap()
+        .get_double()? as usize;
+
+    // --------------------------------------------------------
+    // Create AudioBufferSourceOptions object
+    // --------------------------------------------------------
+    let options = ScriptProcessorOptions {
+        buffer_size,
+        number_of_input_channels,
+        number_of_output_channels,
+    };
+
+    // --------------------------------------------------------
+    // Create native ScriptProcessorNode
+    // --------------------------------------------------------
+    let audio_context_name =
+        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+    let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+    let audio_context_str = &audio_context_utf8_name[..];
+
+    let native_node = match audio_context_str {
+        "AudioContext" => {
+            let napi_audio_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
+            let audio_context = napi_audio_context.unwrap();
+            ScriptProcessorNode::new(audio_context, options)
+        }
+        "OfflineAudioContext" => {
+            let napi_audio_context = ctx
+                .env
+                .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
+            let audio_context = napi_audio_context.unwrap();
+            ScriptProcessorNode::new(audio_context, options)
+        }
+        &_ => panic!("not supported"),
+    };
+
+    // --------------------------------------------------------
+    // Finalize instance creation
+    // --------------------------------------------------------
+    js_this.define_properties(&[
+        Property::new("context")?
+            .with_value(&js_audio_context)
+            .with_property_attributes(PropertyAttributes::Enumerable),
+        // this must be put on the instance and not in the prototype to be reachable
+        Property::new("Symbol.toStringTag")?
+            .with_value(&ctx.env.create_string("ScriptProcessorNode")?)
+            .with_property_attributes(PropertyAttributes::Static),
+    ])?;
+
+    // finalize instance creation
+    let napi_node = NapiScriptProcessorNode(native_node);
+    ctx.env.wrap(&mut js_this, napi_node)?;
+
+    ctx.env.get_undefined()
+}
+
+audio_node_impl!(NapiScriptProcessorNode);
+
+// -------------------------------------------------
+// ScriptProcessorNode Interface
+// -------------------------------------------------
+
+#[js_function]
+fn get_buffer_size(ctx: CallContext) -> Result<JsNumber> {
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_node = ctx.env.unwrap::<NapiScriptProcessorNode>(&js_this)?;
+    let node = napi_node.unwrap();
+
+    let buffer_size = node.buffer_size() as f64;
+
+    ctx.env.create_double(buffer_size)
+}
+
+// ----------------------------------------------------
+// EventTarget initialization - cf. js/utils/events.js
+// ----------------------------------------------------
+#[js_function]
+fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
+    // use crate::utils::WebAudioEventType;
+    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
+    use web_audio_api::AudioProcessingEvent;
+
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_node = ctx.env.unwrap::<NapiScriptProcessorNode>(&js_this)?;
+    let node = napi_node.unwrap();
+
+    // garb the napi audio context
+    let js_audio_context: JsObject = js_this.get_named_property("context")?;
+    let audio_context_name =
+        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
+    let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
+    let audio_context_str = &audio_context_utf8_name[..];
+
+    let dispatch_event_symbol = ctx
+        .env
+        .symbol_for("node-web-audio-api:napi-dispatch-event")
+        .unwrap();
+    let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
+
+    let tsfn = ctx.env.create_threadsafe_function(
+        &js_func,
+        1,
+        |ctx: ThreadSafeCallContext<AudioProcessingEvent>| {
+            // let native_event = ctx.value.unwrap_audio_processing_event();
+            let event = ctx.value;
+            let event_type = ctx.env.create_string("audioprocessing")?;
+            let _playback_time = ctx.env.create_double(event.playback_time)?;
+            // @todo - input_buffer
+            // @todo - output_buffer
+
+            Ok(vec![event_type])
+        },
+    )?;
+
+    // @note - we have no hint to clear the listener from the tsfn store
+    // cf. napi_unref_threadsafe_function (?)
+    match audio_context_str {
+        "AudioContext" => {
+            // let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
+            // let store_id = napi_context.tsfn_store().add(tsfn.clone());
+            // let napi_context = napi_context.clone();
+
+            node.set_onaudioprocess(move |e| {
+                // let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+            });
+        }
+        "OfflineAudioContext" => {
+            // let napi_context = ctx
+            //     .env
+            //     .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
+            // let store_id = napi_context.tsfn_store().add(tsfn.clone());
+            // let napi_context = napi_context.clone();
+
+            node.set_onaudioprocess(move |e| {
+                // let event = WebAudioEventType::from(e);
+                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+            });
+        }
+        &_ => unreachable!(),
+    };
+
+    ctx.env.get_undefined()
+}

--- a/src/script_processor_node.rs
+++ b/src/script_processor_node.rs
@@ -22,7 +22,7 @@ impl NapiScriptProcessorNode {
     }
 }
 
-#[js_function(1)]
+#[js_function(2)]
 fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     let mut js_this = ctx.this_unchecked::<JsObject>();
 
@@ -145,25 +145,26 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
         .unwrap();
     let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
 
-    let tsfn = ctx.env.create_threadsafe_function(
-        &js_func,
-        1,
-        |ctx: ThreadSafeCallContext<Arc<Mutex<AudioProcessingEvent>>>| {
-            // let native_event = ctx.value.unwrap_audio_processing_event();
-            let event = ctx.value.lock().unwrap();
-            // let lock = event.
-            let event_type = ctx.env.create_string("audioprocessing")?;
-            let playback_time = ctx.env.create_double(event.playback_time)?;
-            // @todo - input_buffer
-            // @todo - output_buffer
-
-            let mut arg = ctx.env.create_object()?;
-            arg.set_named_property("type", event_type)?;
-            arg.set_named_property("playbackTime", playback_time)?;
-
-            Ok(vec![arg])
-        },
-    )?;
+    let tsfn =
+        ctx.env
+            .create_threadsafe_function(&js_func, 1, |ctx: ThreadSafeCallContext<()>| {
+                println!("coucou");
+                // let native_event = ctx.value.unwrap_audio_processing_event();
+                // let event = ctx.value.lock().unwrap();
+                // // let lock = event.
+                // let event_type = ctx.env.create_string("audioprocessing")?;
+                // let playback_time = ctx.env.create_double(event.playback_time)?;
+                // // @todo - input_buffer
+                // // @todo - output_buffer
+                // println!("{:?}", event.playback_time);
+                // println!("{:?}", event.input_buffer);
+                // println!("{:?}", event.output_buffer);
+                // let mut arg = ctx.env.create_object()?;
+                // arg.set_named_property("type", event_type)?;
+                // arg.set_named_property("playbackTime", playback_time)?;
+                let type_ = "audioprocessing";
+                Ok(vec![type_])
+            })?;
 
     // @note - we have no hint to clear the listener from the tsfn store
     // cf. napi_unref_threadsafe_function (?)
@@ -174,8 +175,9 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
             // let napi_context = napi_context.clone();
 
             node.set_onaudioprocess(move |e| {
+                // println!("coucou");
                 // let event = WebAudioEventType::from(e);
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+                tsfn.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
             });
         }
         "OfflineAudioContext" => {
@@ -187,7 +189,7 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
 
             node.set_onaudioprocess(move |e| {
                 // let event = WebAudioEventType::from(e);
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+                tsfn.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
             });
         }
         &_ => unreachable!(),

--- a/src/script_processor_node.rs
+++ b/src/script_processor_node.rs
@@ -182,6 +182,7 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
             napi_output_buffer.populate(output_buffer);
 
             // create js event
+            // @todo - find a way to reuse the same instance
             let mut js_event = ctx.env.create_object()?;
             js_event.set_named_property("type", event_type)?;
             js_event.set_named_property("playbackTime", playback_time)?;

--- a/src/script_processor_node.rs
+++ b/src/script_processor_node.rs
@@ -208,10 +208,8 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
         },
     )?;
 
-    // @note - we have no hint to clear the listener from the tsfn store when
-    // the node is deleted from the graph. For now, this will be deleted only
-    // when the context is closed.
-    // cf. napi_unref_threadsafe_function (?)
+    // @problem - we have no way to clear the listener, so the process is not
+    // exited even when the context is closed...
     match audio_context_str {
         "AudioContext" => {
             // let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;

--- a/src/script_processor_node.rs
+++ b/src/script_processor_node.rs
@@ -164,7 +164,7 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
 
             let js_input_buffer = ctor.new_instance(&[options])?;
             let napi_input_buffer = ctx.env.unwrap::<NapiAudioBuffer>(&js_input_buffer)?;
-            // grab the input buffer from event so we don't need to clone the it
+            // grab input buffer from event to give it Napi AudioBuffer
             let input_tumbstone = AudioBuffer::from(vec![vec![]], 48_000.);
             let input_buffer = std::mem::replace(&mut event.input_buffer, input_tumbstone);
             napi_input_buffer.populate(input_buffer);
@@ -175,10 +175,9 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
 
             let js_output_buffer = ctor.new_instance(&[options])?;
             let napi_output_buffer = ctx.env.unwrap::<NapiAudioBuffer>(&js_output_buffer)?;
-            // grab the output buffer from event so we don't need to clone the it
+            // grab output buffer from event to give it Napi AudioBuffer
             let output_tumbstone = AudioBuffer::from(vec![vec![]], 48_000.);
             let output_buffer = std::mem::replace(&mut event.output_buffer, output_tumbstone);
-            println!("0. before js call ({:?}):", &output_buffer);
             napi_output_buffer.populate(output_buffer);
 
             // create js event
@@ -199,11 +198,6 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
             )?;
 
             let mut output_buffer = napi_output_buffer.take();
-            let mut test = [0.; 10];
-            output_buffer.copy_from_channel(&mut test, 0);
-            println!("2. after js call ({:?}): {:?}", &output_buffer, test);
-
-            // put back the output audio buffer into the rust event
             std::mem::swap(&mut event.output_buffer, &mut output_buffer);
 
             Ok(())

--- a/src/script_processor_node.rs
+++ b/src/script_processor_node.rs
@@ -146,9 +146,10 @@ fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
     let tsfn = ctx.env.create_threadsafe_function(
         &js_func,
         1,
-        |ctx: ThreadSafeCallContext<AudioProcessingEvent>| {
+        |ctx: ThreadSafeCallContext<Arc<Mutex<AudioProcessingEvent>>>| {
             // let native_event = ctx.value.unwrap_audio_processing_event();
             let event = ctx.value;
+            // let lock = event.
             let event_type = ctx.env.create_string("audioprocessing")?;
             let _playback_time = ctx.env.create_double(event.playback_time)?;
             // @todo - input_buffer

--- a/src/stereo_panner_node.rs
+++ b/src/stereo_panner_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiStereoPannerNode(StereoPannerNode);
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,9 @@
 mod tsfn_store;
 pub(crate) use tsfn_store::*;
 
+mod thread_safe_function;
+pub(crate) use thread_safe_function::*;
+
 // cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
 #[allow(clippy::needless_lifetimes)]
 pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,8 @@
+mod tsfn_store;
+pub(crate) use tsfn_store::*;
+
+// cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
+#[allow(clippy::needless_lifetimes)]
+pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {
+    unsafe { std::slice::from_raw_parts(floats.as_ptr() as *const _, floats.len() * 4) }
+}

--- a/src/utils/thread_safe_function.rs
+++ b/src/utils/thread_safe_function.rs
@@ -1,0 +1,305 @@
+// cf. https://github.com/napi-rs/napi-rs/issues/1307
+// cf. https://github.com/NomicFoundation/hardhat/blob/7087f3407ae46aa80e61b24b0a4a81f264993768/crates/rethnet_evm_napi/src/threadsafe_function.rs
+
+// Fork of threadsafe_function from napi-rs that allows calling JS function manually rather than
+// only returning args. This enables us to use the return value of the function.
+
+#![allow(clippy::single_component_path_imports)]
+
+use std::{
+    convert::Into,
+    ffi::CString,
+    marker::PhantomData,
+    os::raw::c_void,
+    ptr,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use napi::{check_status, sys, Env, JsError, JsFunction, NapiValue, Result, Status};
+
+/// ThreadSafeFunction Context object
+/// the `value` is the value passed to `call` method
+pub struct ThreadSafeCallContext<T: 'static> {
+    pub env: Env,
+    pub value: T,
+    pub callback: JsFunction,
+}
+
+#[repr(u8)]
+pub enum ThreadsafeFunctionCallMode {
+    NonBlocking,
+    Blocking,
+}
+
+impl From<ThreadsafeFunctionCallMode> for sys::napi_threadsafe_function_call_mode {
+    fn from(value: ThreadsafeFunctionCallMode) -> Self {
+        match value {
+            ThreadsafeFunctionCallMode::Blocking => sys::ThreadsafeFunctionCallMode::blocking,
+            ThreadsafeFunctionCallMode::NonBlocking => sys::ThreadsafeFunctionCallMode::nonblocking,
+        }
+    }
+}
+
+/// Communicate with the addon's main thread by invoking a JavaScript function from other threads.
+///
+/// ## Example
+/// An example of using `ThreadsafeFunction`:
+///
+/// ```rust
+/// #[macro_use]
+/// extern crate napi_derive;
+///
+/// use std::thread;
+///
+/// use napi::{
+///     threadsafe_function::{
+///         ThreadSafeCallContext, ThreadsafeFunctionCallMode, ThreadsafeFunctionReleaseMode,
+///     },
+///     CallContext, Error, JsFunction, JsNumber, JsUndefined, Result, Status,
+/// };
+///
+/// #[js_function(1)]
+/// pub fn test_threadsafe_function(ctx: CallContext) -> Result<JsUndefined> {
+///   let func = ctx.get::<JsFunction>(0)?;
+///
+///   let tsfn =
+///       ctx
+///           .env
+///           .create_threadsafe_function(&func, 0, |ctx: ThreadSafeCallContext<Vec<u32>>| {
+///             ctx.value
+///                 .iter()
+///                 .map(|v| ctx.env.create_uint32(*v))
+///                 .collect::<Result<Vec<JsNumber>>>()
+///           })?;
+///
+///   let tsfn_cloned = tsfn.clone();
+///
+///   thread::spawn(move || {
+///       let output: Vec<u32> = vec![0, 1, 2, 3];
+///       // It's okay to call a threadsafe function multiple times.
+///       tsfn.call(Ok(output.clone()), ThreadsafeFunctionCallMode::Blocking);
+///   });
+///
+///   thread::spawn(move || {
+///       let output: Vec<u32> = vec![3, 2, 1, 0];
+///       // It's okay to call a threadsafe function multiple times.
+///       tsfn_cloned.call(Ok(output.clone()), ThreadsafeFunctionCallMode::NonBlocking);
+///   });
+///
+///   ctx.env.get_undefined()
+/// }
+/// ```
+pub struct ThreadsafeFunction<T: 'static> {
+    raw_tsfn: sys::napi_threadsafe_function,
+    aborted: Arc<AtomicBool>,
+    ref_count: Arc<AtomicUsize>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: 'static> Clone for ThreadsafeFunction<T> {
+    fn clone(&self) -> Self {
+        if !self.aborted.load(Ordering::Acquire) {
+            let acquire_status = unsafe { sys::napi_acquire_threadsafe_function(self.raw_tsfn) };
+            debug_assert!(
+                acquire_status == sys::Status::napi_ok,
+                "Acquire threadsafe function failed in clone"
+            );
+        }
+
+        Self {
+            raw_tsfn: self.raw_tsfn,
+            aborted: Arc::clone(&self.aborted),
+            ref_count: Arc::clone(&self.ref_count),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+unsafe impl<T> Send for ThreadsafeFunction<T> {}
+unsafe impl<T> Sync for ThreadsafeFunction<T> {}
+
+impl<T: 'static> ThreadsafeFunction<T> {
+    /// See [napi_create_threadsafe_function](https://nodejs.org/api/n-api.html#n_api_napi_create_threadsafe_function)
+    /// for more information.
+    pub(crate) fn create<R: 'static + Send + FnMut(ThreadSafeCallContext<T>) -> Result<()>>(
+        env: sys::napi_env,
+        func: sys::napi_value,
+        max_queue_size: usize,
+        callback: R,
+    ) -> Result<Self> {
+        let mut async_resource_name = ptr::null_mut();
+        let s = "napi_rs_threadsafe_function";
+        let len = s.len();
+        let s = CString::new(s)?;
+        check_status!(unsafe {
+            sys::napi_create_string_utf8(env, s.as_ptr(), len, &mut async_resource_name)
+        })?;
+
+        let initial_thread_count = 1usize;
+        let mut raw_tsfn = ptr::null_mut();
+        let ptr = Box::into_raw(Box::new(callback)) as *mut c_void;
+        check_status!(unsafe {
+            sys::napi_create_threadsafe_function(
+                env,
+                func,
+                ptr::null_mut(),
+                async_resource_name,
+                max_queue_size,
+                initial_thread_count,
+                ptr,
+                Some(thread_finalize_cb::<T, R>),
+                ptr,
+                Some(call_js_cb::<T, R>),
+                &mut raw_tsfn,
+            )
+        })?;
+
+        let aborted = Arc::new(AtomicBool::new(false));
+        let aborted_ptr = Arc::into_raw(aborted.clone()) as *mut c_void;
+        check_status!(unsafe {
+            sys::napi_add_env_cleanup_hook(env, Some(cleanup_cb), aborted_ptr)
+        })?;
+
+        Ok(ThreadsafeFunction {
+            raw_tsfn,
+            aborted,
+            ref_count: Arc::new(AtomicUsize::new(initial_thread_count)),
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<T: 'static> ThreadsafeFunction<T> {
+    /// See [napi_call_threadsafe_function](https://nodejs.org/api/n-api.html#n_api_napi_call_threadsafe_function)
+    /// for more information.
+    pub fn call(&self, value: T, mode: ThreadsafeFunctionCallMode) -> Status {
+        if self.aborted.load(Ordering::Acquire) {
+            return Status::Closing;
+        }
+        unsafe {
+            sys::napi_call_threadsafe_function(
+                self.raw_tsfn,
+                Box::into_raw(Box::new(value)) as *mut _,
+                mode.into(),
+            )
+        }
+        .into()
+    }
+}
+
+impl<T: 'static> Drop for ThreadsafeFunction<T> {
+    fn drop(&mut self) {
+        if !self.aborted.load(Ordering::Acquire) && self.ref_count.load(Ordering::Acquire) > 0usize
+        {
+            let release_status = unsafe {
+                sys::napi_release_threadsafe_function(
+                    self.raw_tsfn,
+                    sys::ThreadsafeFunctionReleaseMode::release,
+                )
+            };
+            assert!(
+                release_status == sys::Status::napi_ok,
+                "Threadsafe Function release failed"
+            );
+        }
+    }
+}
+
+unsafe extern "C" fn cleanup_cb(cleanup_data: *mut c_void) {
+    let aborted = Arc::<AtomicBool>::from_raw(cleanup_data.cast());
+    aborted.store(true, Ordering::SeqCst);
+}
+
+unsafe extern "C" fn thread_finalize_cb<T: 'static, R>(
+    _raw_env: sys::napi_env,
+    finalize_data: *mut c_void,
+    _finalize_hint: *mut c_void,
+) where
+    R: 'static + Send + FnMut(ThreadSafeCallContext<T>) -> Result<()>,
+{
+    // cleanup
+    drop(Box::<R>::from_raw(finalize_data.cast()));
+}
+
+unsafe extern "C" fn call_js_cb<T: 'static, R>(
+    raw_env: sys::napi_env,
+    js_callback: sys::napi_value,
+    context: *mut c_void,
+    data: *mut c_void,
+) where
+    R: 'static + Send + FnMut(ThreadSafeCallContext<T>) -> Result<()>,
+{
+    // env and/or callback can be null when shutting down
+    if raw_env.is_null() || js_callback.is_null() {
+        return;
+    }
+
+    let ctx: &mut R = &mut *context.cast::<R>();
+    let val: Result<T> = Ok(*Box::<T>::from_raw(data.cast()));
+
+    let mut recv = ptr::null_mut();
+    sys::napi_get_undefined(raw_env, &mut recv);
+
+    let ret = val.and_then(|v| {
+        (ctx)(ThreadSafeCallContext {
+            env: Env::from_raw(raw_env),
+            value: v,
+            callback: JsFunction::from_raw(raw_env, js_callback).unwrap(), // TODO: unwrap
+        })
+    });
+
+    let status = match ret {
+        Ok(()) => sys::Status::napi_ok,
+        Err(e) => sys::napi_fatal_exception(raw_env, JsError::from(e).into_value(raw_env)),
+    };
+    if status == sys::Status::napi_ok {
+        return;
+    }
+    if status == sys::Status::napi_pending_exception {
+        let mut error_result = ptr::null_mut();
+        assert_eq!(
+            sys::napi_get_and_clear_last_exception(raw_env, &mut error_result),
+            sys::Status::napi_ok
+        );
+
+        // When shutting down, napi_fatal_exception sometimes returns another exception
+        let stat = sys::napi_fatal_exception(raw_env, error_result);
+        assert!(stat == sys::Status::napi_ok || stat == sys::Status::napi_pending_exception);
+    } else {
+        let error_code: Status = status.into();
+        let error_code_string = format!("{:?}", error_code);
+        let mut error_code_value = ptr::null_mut();
+        assert_eq!(
+            sys::napi_create_string_utf8(
+                raw_env,
+                error_code_string.as_ptr() as *const _,
+                error_code_string.len(),
+                &mut error_code_value,
+            ),
+            sys::Status::napi_ok,
+        );
+        let error_msg = "Call JavaScript callback failed in thread safe function";
+        let mut error_msg_value = ptr::null_mut();
+        assert_eq!(
+            sys::napi_create_string_utf8(
+                raw_env,
+                error_msg.as_ptr() as *const _,
+                error_msg.len(),
+                &mut error_msg_value,
+            ),
+            sys::Status::napi_ok,
+        );
+        let mut error_value = ptr::null_mut();
+        assert_eq!(
+            sys::napi_create_error(raw_env, error_code_value, error_msg_value, &mut error_value),
+            sys::Status::napi_ok,
+        );
+        assert_eq!(
+            sys::napi_fatal_exception(raw_env, error_value),
+            sys::Status::napi_ok
+        );
+    }
+}

--- a/src/utils/tsfn_store.rs
+++ b/src/utils/tsfn_store.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use napi::threadsafe_function::ThreadsafeFunction;
+use uuid::Uuid;
+use web_audio_api::{AudioProcessingEvent, ErrorEvent, Event, OfflineAudioCompletionEvent};
+
+pub(crate) enum WebAudioEventType {
+    Event(Event),
+    ErrorEvent(ErrorEvent),
+    AudioProcessingEvent(AudioProcessingEvent),
+    OfflineAudioCompletionEvent(OfflineAudioCompletionEvent),
+}
+
+impl From<Event> for WebAudioEventType {
+    fn from(e: Event) -> WebAudioEventType {
+        WebAudioEventType::Event(e)
+    }
+}
+
+impl From<ErrorEvent> for WebAudioEventType {
+    fn from(e: ErrorEvent) -> WebAudioEventType {
+        WebAudioEventType::ErrorEvent(e)
+    }
+}
+
+impl From<AudioProcessingEvent> for WebAudioEventType {
+    fn from(e: AudioProcessingEvent) -> WebAudioEventType {
+        WebAudioEventType::AudioProcessingEvent(e)
+    }
+}
+
+impl From<OfflineAudioCompletionEvent> for WebAudioEventType {
+    fn from(e: OfflineAudioCompletionEvent) -> WebAudioEventType {
+        WebAudioEventType::OfflineAudioCompletionEvent(e)
+    }
+}
+
+impl WebAudioEventType {
+    pub fn unwrap_event(self) -> Event {
+        match self {
+            WebAudioEventType::Event(e) => e,
+            _ => unreachable!(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn unwrap_error_event(self) -> ErrorEvent {
+        match self {
+            WebAudioEventType::ErrorEvent(e) => e,
+            _ => unreachable!(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn unwrap_audio_processing_event(self) -> AudioProcessingEvent {
+        match self {
+            WebAudioEventType::AudioProcessingEvent(e) => e,
+            _ => unreachable!(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn unwrap_offline_audio_completion_event(self) -> OfflineAudioCompletionEvent {
+        match self {
+            WebAudioEventType::OfflineAudioCompletionEvent(e) => e,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TsfnStore {
+    store: Arc<Mutex<HashMap<String, ThreadsafeFunction<WebAudioEventType>>>>,
+}
+
+impl TsfnStore {
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    // called from main thread
+    pub fn add(&self, tsfn: ThreadsafeFunction<WebAudioEventType>) -> String {
+        let mut store = self.store.lock().unwrap();
+        let uuid = Uuid::new_v4();
+        store.insert(uuid.to_string(), tsfn);
+
+        uuid.to_string()
+    }
+
+    // We need to clean things around so that the js object can be garbage collected.
+    // But we also need to wait so that the previous tsfn.call is executed.
+    // This is not clean, but don't see how to implement that properly right now.
+    //
+    // called from EventLoop thread
+    pub fn delete(&self, store_id: String) {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        let mut store = self.store.lock().unwrap();
+
+        if let Some(tsfn) = store.remove(&store_id) {
+            let _ = tsfn.abort();
+        }
+    }
+
+    // called from EventLoop thread
+    pub fn clear(&self) {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        let mut store = self.store.lock().unwrap();
+
+        for (_, tsfn) in store.drain() {
+            let _ = tsfn.abort();
+        }
+    }
+}

--- a/src/wave_shaper_node.rs
+++ b/src/wave_shaper_node.rs
@@ -17,10 +17,11 @@
 // -------------------------------------------------------------------------- //
 // -------------------------------------------------------------------------- //
 
-use crate::*;
 use napi::*;
 use napi_derive::js_function;
 use web_audio_api::node::*;
+
+use crate::*;
 
 pub(crate) struct NapiWaveShaperNode(WaveShaperNode);
 
@@ -204,7 +205,7 @@ fn get_curve(ctx: CallContext) -> Result<JsUnknown> {
 
     if let Some(arr_f32) = value {
         let length = arr_f32.len();
-        let arr_u8 = crate::to_byte_slice(arr_f32);
+        let arr_u8 = crate::utils::to_byte_slice(arr_f32);
 
         Ok(ctx
             .env


### PR DESCRIPTION
First (...failed) attempt

### To make it short
- I think the rust API is nice/idiomatic/relevant as it is
- I have no idea how I can deal with it

### Most simplified example

relevant code is here: <https://github.com/ircam-ismm/node-web-audio-api/compare/feat/script-processor?expand=1#diff-f2a3e90afd7d940e52b634347f9a1e12ee21402dafa586f92c960ad13fa052fcR146>

In short:

```rs

node.set_onaudioprocess(move |e| {
    tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
});
```

### Problem

```
error[E0521]: borrowed data escapes outside of closure
   --> src/script_processor_node.rs:171:17
    |
169 |             node.set_onaudioprocess(move |e| {
    |                                           -
    |                                           |
    |                                           `e` is a reference that is only valid in the closure body
    |                                           has type `&'1 mut AudioProcessingEvent`
170 |                 // let event = WebAudioEventType::from(e);
171 |                 tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                 |
    |                 `e` escapes the closure body here
    |                 argument requires that `'1` must outlive `'static`
```

\o/