### PR TITLE
Refactor - review events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = {version="2.15", features=["napi9", "tokio_rt"]}
 napi-derive = "2.15"
-uuid = {version="1.6.1", features = ["v4", "fast-rng"]}
 web-audio-api = "=1.0.0-rc.5"
 # web-audio-api = { path = "../web-audio-api-rs" }
 

--- a/examples/change-state.mjs
+++ b/examples/change-state.mjs
@@ -15,10 +15,10 @@ audioContext.onstatechange = event => {
   console.log('onstatechange (called first):', event);
 };
 
-// const sine = audioContext.createOscillator();
-// sine.connect(audioContext.destination);
-// sine.frequency.value = 200;
-// sine.start();
+const sine = audioContext.createOscillator();
+sine.connect(audioContext.destination);
+sine.frequency.value = 200;
+sine.start();
 
 console.log('> Playback for 1 seconds');
 await new Promise(resolve => setTimeout(resolve, 1000));

--- a/examples/change-state.mjs
+++ b/examples/change-state.mjs
@@ -15,10 +15,10 @@ audioContext.onstatechange = event => {
   console.log('onstatechange (called first):', event);
 };
 
-const sine = audioContext.createOscillator();
-sine.connect(audioContext.destination);
-sine.frequency.value = 200;
-sine.start();
+// const sine = audioContext.createOscillator();
+// sine.connect(audioContext.destination);
+// sine.frequency.value = 200;
+// sine.start();
 
 console.log('> Playback for 1 seconds');
 await new Promise(resolve => setTimeout(resolve, 1000));

--- a/examples/offline.mjs
+++ b/examples/offline.mjs
@@ -2,13 +2,8 @@ import { AudioContext, OfflineAudioContext } from '../index.mjs';
 
 const offline = new OfflineAudioContext(1, 48000, 48000);
 
-
-let aResult = null;
-let bResult = null;
-
 offline.addEventListener('complete', (e) => {
   console.log('+ complete event:', e.renderedBuffer.toString());
-  aResult = e.renderedBuffer;
 });
 
 offline.suspend(128 / 48000).then(async () => {
@@ -21,30 +16,22 @@ offline.suspend(128 / 48000).then(async () => {
   await offline.resume();
 });
 
-// offline.startRendering().then(audioBuffer => console.log(audioBuffer));
 const buffer = await offline.startRendering();
 console.log('+ buffer duration:', buffer.duration);
 
-bResult = buffer;
+console.log('')
+console.log('> Playback computed buffer in loop, should hear a small silent gap in the middle');
 
-await new Promise(resolve => setTimeout(resolve, 100));
+const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
+const online = new AudioContext({ latencyHint });
 
-console.log(aResult === bResult);
+const src = online.createBufferSource();
+src.buffer = buffer;
+src.loop = true;
+src.connect(online.destination);
+src.start();
 
-// console.log('')
-// console.log('> Playback computed buffer in loop, should hear a small silent gap in the middle');
+await new Promise(resolve => setTimeout(resolve, 2000));
 
-// const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
-// const online = new AudioContext({ latencyHint });
-
-// const src = online.createBufferSource();
-// // src.loop = true;
-// src.buffer = aResult;
-// src.loop = true;
-// src.connect(online.destination);
-// src.start();
-
-// await new Promise(resolve => setTimeout(resolve, 2000));
-
-// console.log('close context');
-// await online.close();
+console.log('+ close context');
+await online.close();

--- a/examples/offline.mjs
+++ b/examples/offline.mjs
@@ -2,8 +2,13 @@ import { AudioContext, OfflineAudioContext } from '../index.mjs';
 
 const offline = new OfflineAudioContext(1, 48000, 48000);
 
+
+let aResult = null;
+let bResult = null;
+
 offline.addEventListener('complete', (e) => {
   console.log('+ complete event:', e.renderedBuffer.toString());
+  aResult = e.renderedBuffer;
 });
 
 offline.suspend(128 / 48000).then(async () => {
@@ -20,20 +25,26 @@ offline.suspend(128 / 48000).then(async () => {
 const buffer = await offline.startRendering();
 console.log('+ buffer duration:', buffer.duration);
 
-console.log('')
-console.log('> Playback computed buffer in loop, should hear a small silent gap in the middle');
+bResult = buffer;
 
-const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
-const online = new AudioContext({ latencyHint });
+await new Promise(resolve => setTimeout(resolve, 100));
 
-const src = online.createBufferSource();
+console.log(aResult === bResult);
+
+// console.log('')
+// console.log('> Playback computed buffer in loop, should hear a small silent gap in the middle');
+
+// const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
+// const online = new AudioContext({ latencyHint });
+
+// const src = online.createBufferSource();
+// // src.loop = true;
+// src.buffer = aResult;
 // src.loop = true;
-src.buffer = buffer;
-src.loop = true;
-src.connect(online.destination);
-src.start();
+// src.connect(online.destination);
+// src.start();
 
-await new Promise(resolve => setTimeout(resolve, 2000));
+// await new Promise(resolve => setTimeout(resolve, 2000));
 
-console.log('close context');
-await online.close();
+// console.log('close context');
+// await online.close();

--- a/generator/js/AudioNodes.tmpl.js
+++ b/generator/js/AudioNodes.tmpl.js
@@ -15,9 +15,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const ${d.parent(d.node)} = require('./${d.parent(d.node)}.js');
@@ -313,10 +310,6 @@ module.exports = (jsExport, nativeBinding) => {
           }
         }).join('');
       }())}
-
-      ${d.parent(d.node) === 'AudioScheduledSourceNode' ? `
-      // Bridge Rust native event to Node EventTarget
-      bridgeEventTarget(this);` : ``}
 
       ${d.audioParams(d.node).map(param => {
         return `

--- a/generator/js/index.tmpl.mjs
+++ b/generator/js/index.tmpl.mjs
@@ -6,6 +6,10 @@ const require = createRequire(import.meta.url);
 
 const nativeModule = require('./index.cjs');
 export const {
+  // events
+  OfflineAudioCompletionEvent,
+
+  // manually written nodes
   BaseAudioContext,
   AudioContext,
   OfflineAudioContext,
@@ -18,7 +22,7 @@ export const {
 
   PeriodicWave,
   AudioBuffer,
-  // generated supported nodes
+  // generated nodes
 ${d.nodes.map(n => `  ${d.name(n)},`).join('\n')}
 
   // helper methods

--- a/generator/js/monkey-patch.tmpl.js
+++ b/generator/js/monkey-patch.tmpl.js
@@ -1,7 +1,12 @@
 module.exports = function monkeyPatch(nativeBinding) {
   let jsExport = {};
+
   // --------------------------------------------------------------------------
-  // Monkey Patch Web Audio API
+  // Events
+  // --------------------------------------------------------------------------
+  jsExport.OfflineAudioCompletionEvent = require('./Events').OfflineAudioCompletionEvent;
+  // --------------------------------------------------------------------------
+  // Create Web Audio API facade
   // --------------------------------------------------------------------------
   jsExport.BaseAudioContext = require('./BaseAudioContext.js')(jsExport, nativeBinding);
   jsExport.AudioContext = require('./AudioContext.js')(jsExport, nativeBinding);

--- a/generator/rs/audio_nodes.tmpl.rs
+++ b/generator/rs/audio_nodes.tmpl.rs
@@ -6,11 +6,11 @@ use crate::*;
 pub(crate) struct ${d.napiName(d.node)}(${d.name(d.node)});
 
 // for debug purpose
-// impl Drop for ${d.napiName(d.node)} {
-//     fn drop(&mut self) {
-//         println!("NAPI: ${d.napiName(d.node)} dropped");
-//     }
-// }
+impl Drop for ${d.napiName(d.node)} {
+    fn drop(&mut self) {
+        println!("NAPI: ${d.napiName(d.node)} dropped");
+    }
+}
 
 impl ${d.napiName(d.node)} {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -29,10 +29,9 @@ impl ${d.napiName(d.node)} {
                 `);
 
             if (d.parent(d.node) === "AudioScheduledSourceNode") {
-                // AudioScheduledSourceNode interface
                 methods.push(`Property::new("start")?.with_method(start)`);
                 methods.push(`Property::new("stop")?.with_method(stop)`);
-                methods.push(`Property::new("__initEventTarget__")?.with_method(init_event_target)`);
+                methods.push(`Property::new("clear_ended_callback")?.with_method(clear_ended_callback)`);
             }
 
             let interface = attributes.concat(methods);
@@ -45,7 +44,7 @@ impl ${d.napiName(d.node)} {
         env.define_class("${d.name(d.node)}", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut ${d.name(d.node)} {
         &mut self.0
     }
@@ -332,7 +331,57 @@ ${(function() {
         let methods = `
 // -------------------------------------------------
 // AudioScheduledSourceNode Interface
-// -------------------------------------------------\
+// -------------------------------------------------
+fn listen_to_ended_event(
+    env: &Env,
+    js_this: &JsObject,
+    node: &mut ${d.name(d.node)},
+) -> Result<()> {
+    use std::sync::{Arc, Mutex};
+
+    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
+    use web_audio_api::Event;
+
+    let k_onended = get_symbol_for(env, "node-web-audio-api:onended");
+    let ended_cb = js_this.get_property(k_onended).unwrap();
+    let mut ended_tsfn = env.create_threadsafe_function(
+        &ended_cb,
+        0,
+        |ctx: ThreadSafeCallContext<Event>| {
+            let mut event = ctx.env.create_object()?;
+            let event_type = ctx.env.create_string(ctx.value.type_)?;
+            event.set_named_property("type", event_type)?;
+
+            Ok(vec![event])
+        },
+    )?;
+
+    // unref tsfn so they do not prevent the process to exit
+    // let _ = ended_tsfn.unref(env);
+    let ended_tsfn_mutex = Arc::new(Mutex::new(ended_tsfn.clone()));
+
+    node.set_onended(move |e| {
+        ended_tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+        // even with unref, if the tsfn is not aborted, the node cannot
+        // be garbage collected
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let ended_tsfn = ended_tsfn_mutex.lock().unwrap();
+        let _ = ended_tsfn.clone().abort();
+    });
+
+    Ok(())
+}
+
+#[js_function]
+fn clear_ended_callback(ctx: CallContext) -> Result<JsUndefined> {
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_node = ctx.env.unwrap::<${d.napiName(d.node)}>(&js_this)?;
+    let node = napi_node.unwrap();
+
+    // node.clear_onended();
+
+    ctx.env.get_undefined()
+}
         `;
 
         if (d.name(d.node) !== "AudioBufferSourceNode") {
@@ -342,6 +391,8 @@ fn start(ctx: CallContext) -> Result<JsUndefined> {
     let js_this = ctx.this_unchecked::<JsObject>();
     let napi_node = ctx.env.unwrap::<${d.napiName(d.node)}>(&js_this)?;
     let node = napi_node.unwrap();
+
+    listen_to_ended_event(ctx.env, &js_this, node)?;
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
     node.start_at(when);
@@ -356,6 +407,8 @@ fn start(ctx: CallContext) -> Result<JsUndefined> {
     let js_this = ctx.this_unchecked::<JsObject>();
     let napi_node = ctx.env.unwrap::<${d.napiName(d.node)}>(&js_this)?;
     let node = napi_node.unwrap();
+
+    listen_to_ended_event(ctx.env, &js_this, node)?;
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
 
@@ -389,62 +442,6 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
     node.stop_at(when);
-
-    ctx.env.get_undefined()
-}
-        `;
-
-        methods += `
-// ----------------------------------------------------
-// EventTarget initialization - cf. js/utils/events.js
-// ----------------------------------------------------
-#[js_function]
-fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
-    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
-    use web_audio_api::Event;
-
-    let js_this = ctx.this_unchecked::<JsObject>();
-    let napi_node = ctx.env.unwrap::<${d.napiName(d.node)}>(&js_this)?;
-    let node = napi_node.unwrap();
-
-    // garb the napi audio context
-    let js_audio_context: JsObject = js_this.get_named_property("context")?;
-    let audio_context_name =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-    let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-    let audio_context_str = &audio_context_utf8_name[..];
-
-    let dispatch_event_symbol = ctx.env.symbol_for("node-web-audio-api:napi-dispatch-event").unwrap();
-    let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
-
-    let tsfn = ctx.env.create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-        let event_type = ctx.env.create_string(ctx.value.type_)?;
-        Ok(vec![event_type])
-    })?;
-
-    match audio_context_str {
-        "AudioContext" => {
-            let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        "OfflineAudioContext" => {
-            let napi_context = ctx.env.unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        &_ => unreachable!(),
-    };
 
     ctx.env.get_undefined()
 }

--- a/generator/rs/lib.tmpl.rs
+++ b/generator/rs/lib.tmpl.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use napi::{Env, JsObject, Result};
+use napi::{Env, JsObject, JsSymbol, Result};
 use napi_derive::module_exports;
 
 // cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
@@ -9,6 +9,10 @@ pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {
     unsafe {
         std::slice::from_raw_parts(floats.as_ptr() as *const _, floats.len() * 4)
     }
+}
+
+pub(crate) fn get_symbol_for(env: &Env, name: &str) -> JsSymbol {
+    env.symbol_for(name).unwrap()
 }
 
 #[macro_use]

--- a/generator/rs/lib.tmpl.rs
+++ b/generator/rs/lib.tmpl.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use napi::{Env, JsObject, JsSymbol, Result};
+use napi::{Env, JsFunction, JsObject, JsSymbol, Result};
 use napi_derive::module_exports;
 
 // cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
@@ -13,6 +13,13 @@ pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {
 
 pub(crate) fn get_symbol_for(env: &Env, name: &str) -> JsSymbol {
     env.symbol_for(name).unwrap()
+}
+
+pub(crate) fn get_class_ctor(env: &Env, name: &str) -> Result<JsFunction> {
+    let store_ref: &mut napi::Ref<()> = env.get_instance_data()?.unwrap();
+    let store: JsObject = env.get_reference_value(store_ref)?;
+    let ctor: JsFunction = store.get_named_property(name)?;
+    Ok(ctor)
 }
 
 #[macro_use]

--- a/index.mjs
+++ b/index.mjs
@@ -27,6 +27,10 @@ const require = createRequire(import.meta.url);
 
 const nativeModule = require('./index.cjs');
 export const {
+  // events
+  OfflineAudioCompletionEvent,
+
+  // manually written nodes
   BaseAudioContext,
   AudioContext,
   OfflineAudioContext,
@@ -39,7 +43,7 @@ export const {
 
   PeriodicWave,
   AudioBuffer,
-  // generated supported nodes
+  // generated nodes
   AnalyserNode,
   AudioBufferSourceNode,
   BiquadFilterNode,

--- a/js/AnalyserNode.js
+++ b/js/AnalyserNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/AudioBufferSourceNode.js
+++ b/js/AudioBufferSourceNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioScheduledSourceNode = require('./AudioScheduledSourceNode.js');
@@ -141,9 +138,6 @@ module.exports = (jsExport, nativeBinding) => {
       if (options && options.buffer !== undefined) {
         this[kAudioBuffer] = options.buffer;
       }
-
-      // Bridge Rust native event to Node EventTarget
-      bridgeEventTarget(this);
 
       this.#playbackRate = new jsExport.AudioParam({
         [kNapiObj]: this[kNapiObj].playbackRate,

--- a/js/AudioContext.js
+++ b/js/AudioContext.js
@@ -13,7 +13,6 @@ const {
   kOnSinkChange,
 } = require('./lib/symbols.js');
 const {
-  bridgeEventTarget,
   propagateEvent,
 } = require('./lib/events.js');
 

--- a/js/AudioContext.js
+++ b/js/AudioContext.js
@@ -9,9 +9,12 @@ const {
 } = require('./lib/utils.js');
 const {
   kNapiObj,
+  kOnStateChange,
+  kOnSinkChange,
 } = require('./lib/symbols.js');
 const {
   bridgeEventTarget,
+  propagateEvent,
 } = require('./lib/events.js');
 
 let contextId = 0;
@@ -82,7 +85,28 @@ module.exports = function(jsExport, nativeBinding) {
       }
 
       // Bridge Rust native event to Node EventTarget
-      bridgeEventTarget(this);
+      // bridgeEventTarget(this);
+      // these method are use by the Napi AudioContext to listen from Rust event
+      // and propagate them to JS
+      this[kNapiObj][kOnStateChange] = (err, rawEvent) => {
+        if (typeof rawEvent !== 'object' && !('type' in rawEvent)) {
+          throw new TypeError('Invalid [kOnStateChange] Invocation: rawEvent should have a type property');
+        }
+
+        const event = new Event(rawEvent.type);
+        propagateEvent(this, event);
+      }
+
+      this[kNapiObj][kOnSinkChange] = (err, rawEvent) => {
+        if (typeof rawEvent !== 'object' && !('type' in rawEvent)) {
+          throw new TypeError('Invalid [kOnSinkChange] Invocation: rawEvent should have a type property');
+        }
+
+        const event = new Event(rawEvent.type);
+        propagateEvent(this, event);
+      }
+
+      this[kNapiObj].listen_to_events();
 
       // @todo - check if this is still required
       // prevent garbage collection and process exit

--- a/js/AudioContext.js
+++ b/js/AudioContext.js
@@ -84,10 +84,7 @@ module.exports = function(jsExport, nativeBinding) {
         this.#sinkId = options.sinkId;
       }
 
-      // Bridge Rust native event to Node EventTarget
-      // bridgeEventTarget(this);
-      // these method are use by the Napi AudioContext to listen from Rust event
-      // and propagate them to JS
+      // Add function to Napi object to bridge from Rust events to JS EventTarget
       this[kNapiObj][kOnStateChange] = (err, rawEvent) => {
         if (typeof rawEvent !== 'object' && !('type' in rawEvent)) {
           throw new TypeError('Invalid [kOnStateChange] Invocation: rawEvent should have a type property');
@@ -106,6 +103,9 @@ module.exports = function(jsExport, nativeBinding) {
         propagateEvent(this, event);
       }
 
+      // Workaround to bind the `sinkchange` and `statechange` events to EventTarget.
+      // This must be called from JS facade ctor as the JS handler are added to the Napi
+      // object after its instantiation, and that we don't have any initial `resume` call.
       this[kNapiObj].listen_to_events();
 
       // @todo - check if this is still required

--- a/js/AudioScheduledSourceNode.js
+++ b/js/AudioScheduledSourceNode.js
@@ -4,7 +4,6 @@ const {
   throwSanitizedError,
 } = require('./lib/errors.js');
 const {
-  bridgeEventTarget,
   propagateEvent,
 } = require('./lib/events.js');
 const {
@@ -36,7 +35,7 @@ class AudioScheduledSourceNode extends AudioNode {
     // It will be effectively registered on rust side when `start` is called
     this[kNapiObj][kOnEnded] = (err, rawEvent) => {
       if (typeof rawEvent !== 'object' && !('type' in rawEvent)) {
-        throw new TypeError('Invalid [kOnStateChange] Invocation: rawEvent should have a type property');
+        throw new TypeError('Invalid [kOnEnded] Invocation: rawEvent should have a type property');
       }
 
       const event = new Event(rawEvent.type);

--- a/js/AudioScheduledSourceNode.js
+++ b/js/AudioScheduledSourceNode.js
@@ -39,9 +39,6 @@ class AudioScheduledSourceNode extends AudioNode {
         throw new TypeError('Invalid [kOnStateChange] Invocation: rawEvent should have a type property');
       }
 
-      this[kNapiObj][kOnEnded] = null;
-      // this[kNapiObj]['clear_ended_callback']();
-
       const event = new Event(rawEvent.type);
       propagateEvent(this, event);
     }

--- a/js/BiquadFilterNode.js
+++ b/js/BiquadFilterNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/ChannelMergerNode.js
+++ b/js/ChannelMergerNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/ChannelSplitterNode.js
+++ b/js/ChannelSplitterNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/ConstantSourceNode.js
+++ b/js/ConstantSourceNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioScheduledSourceNode = require('./AudioScheduledSourceNode.js');
@@ -81,9 +78,6 @@ module.exports = (jsExport, nativeBinding) => {
       super(context, {
         [kNapiObj]: napiObj,
       });
-
-      // Bridge Rust native event to Node EventTarget
-      bridgeEventTarget(this);
 
       this.#offset = new jsExport.AudioParam({
         [kNapiObj]: this[kNapiObj].offset,

--- a/js/ConvolverNode.js
+++ b/js/ConvolverNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/DelayNode.js
+++ b/js/DelayNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/DynamicsCompressorNode.js
+++ b/js/DynamicsCompressorNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/Events.js
+++ b/js/Events.js
@@ -1,0 +1,25 @@
+
+// const EndedEvent
+// AudioRenderCapacityEvent
+// OfflineAudioCompletionEvent
+// AudioProcessingEvent
+
+// dictionary EventInit {
+//   boolean bubbles = false;
+//   boolean cancelable = false;
+//   boolean composed = false;
+// };
+
+export class OfflineAudioCompletionEvent extends Event {
+
+  #renderedBuffer = null;
+
+  constructor(type, eventInitDict) {
+    super(type);
+
+  }
+
+  get renderedBuffer() {
+    return this.#renderedBuffer;
+  }
+}

--- a/js/Events.js
+++ b/js/Events.js
@@ -4,19 +4,26 @@
 // OfflineAudioCompletionEvent
 // AudioProcessingEvent
 
+// All this seems to be true in Node.js context
+// cf. https://nodejs.org/api/events.html#class-event
 // dictionary EventInit {
 //   boolean bubbles = false;
 //   boolean cancelable = false;
 //   boolean composed = false;
 // };
 
-export class OfflineAudioCompletionEvent extends Event {
+module.exports.OfflineAudioCompletionEvent = class OfflineAudioCompletionEvent extends Event {
 
   #renderedBuffer = null;
 
   constructor(type, eventInitDict) {
     super(type);
 
+    if (typeof eventInitDict !== 'object' || eventInitDict === null || !('renderedBuffer' in eventInitDict)) {
+      throw TypeError("Failed to construct 'OfflineAudioCompletionEvent': Failed to read the 'renderedBuffer' property from 'OfflineAudioCompletionEvent': Required member is undefined.")
+    }
+
+    this.#renderedBuffer = eventInitDict.renderedBuffer;
   }
 
   get renderedBuffer() {

--- a/js/GainNode.js
+++ b/js/GainNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/IIRFilterNode.js
+++ b/js/IIRFilterNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/MediaStreamAudioSourceNode.js
+++ b/js/MediaStreamAudioSourceNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/OfflineAudioContext.js
+++ b/js/OfflineAudioContext.js
@@ -2,6 +2,7 @@ const conversions = require('webidl-conversions');
 
 const {
   bridgeEventTarget,
+  propagateEvent,
 } = require('./lib/events.js');
 const {
   throwSanitizedError,
@@ -11,19 +12,16 @@ const {
   kEnumerableProperty,
 } = require('./lib/utils.js');
 const {
-  kNapiObj
+  kNapiObj,
+  kOnStateChange,
+  kOnComplete,
 } = require('./lib/symbols.js');
 
-// constructor(OfflineAudioContextOptions contextOptions);
-// constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
-// Promise<AudioBuffer> startRendering();
-// Promise<undefined> resume();
-// Promise<undefined> suspend(double suspendTime);
-// readonly attribute unsigned long length;
-// attribute EventHandler oncomplete;
-
 module.exports = function patchOfflineAudioContext(jsExport, nativeBinding) {
+  console.log(jsExport);
   class OfflineAudioContext extends jsExport.BaseAudioContext {
+    #renderedBuffer = null;
+
     constructor(...args) {
       if (arguments.length < 1) {
         throw new TypeError(`Failed to construct 'OfflineAudioContext': 1 argument required, but only ${arguments.length} present`);
@@ -81,6 +79,36 @@ module.exports = function patchOfflineAudioContext(jsExport, nativeBinding) {
       }
 
       super({ [kNapiObj]: napiObj });
+
+      // Add function to Napi object to bridge from Rust events to JS EventTarget
+      // They will be effectively registered on rust side when `startRendering` is called
+      this[kNapiObj][kOnStateChange] = (err, rawEvent) => {
+        if (typeof rawEvent !== 'object' && !('type' in rawEvent)) {
+          throw new TypeError('Invalid [kOnStateChange] Invocation: rawEvent should have a type property');
+        }
+
+        const event = new Event(rawEvent.type);
+        propagateEvent(this, event);
+      }
+
+      // This event is, per spec, the last trigerred one
+      this[kNapiObj][kOnComplete] = (err, rawEvent) => {
+        if (typeof rawEvent !== 'object' && !('type' in rawEvent)) {
+          throw new TypeError('Invalid [kOnComplete] Invocation: rawEvent should have a type property');
+        }
+
+        // @fixme: workaround the fact that this event seems to be triggered before
+        // startRendering fulfills and that we want to return the exact same instance
+        if (this.#renderedBuffer === null) {
+          this.#renderedBuffer = new jsExport.AudioBuffer({ [kNapiObj]: rawEvent.renderedBuffer });
+        }
+
+        const event = new jsExport.OfflineAudioCompletionEvent(rawEvent.type, {
+          renderedBuffer: this.#renderedBuffer,
+        });
+
+        propagateEvent(this, event);
+      }
     }
 
     get length() {
@@ -114,9 +142,6 @@ module.exports = function patchOfflineAudioContext(jsExport, nativeBinding) {
         throw new TypeError("Invalid Invocation: Value of 'this' must be of type 'OfflineAudioContext'");
       }
 
-      // Lazily register event callback on rust side
-      bridgeEventTarget(this);
-
       let nativeAudioBuffer;
 
       try {
@@ -125,21 +150,13 @@ module.exports = function patchOfflineAudioContext(jsExport, nativeBinding) {
         throwSanitizedError(err);
       }
 
-      const audioBuffer = new jsExport.AudioBuffer({ [kNapiObj]: nativeAudioBuffer });
-
-      // We dispatch the complete event manually to simplify the sharing of the
-      // `AudioBuffer` instance. This also simplifies code on the rust side as
-      // we don't need to deal with the `OfflineAudioCompletionEvent` type.
-      const event = new Event('complete');
-      event.renderedBuffer = audioBuffer;
-
-      if (isFunction(this[`oncomplete`])) {
-        this[`oncomplete`](event);
+      // @fixme: workaround the fact that this event seems to be triggered before
+      // startRendering fulfills and that we want to return the exact same instance
+      if (this.#renderedBuffer === null) {
+        this.#renderedBuffer = new jsExport.AudioBuffer({ [kNapiObj]: nativeAudioBuffer });
       }
 
-      this.dispatchEvent(event);
-
-      return audioBuffer;
+      return this.#renderedBuffer;
     }
 
     async resume() {

--- a/js/OfflineAudioContext.js
+++ b/js/OfflineAudioContext.js
@@ -1,7 +1,6 @@
 const conversions = require('webidl-conversions');
 
 const {
-  bridgeEventTarget,
   propagateEvent,
 } = require('./lib/events.js');
 const {

--- a/js/OfflineAudioContext.js
+++ b/js/OfflineAudioContext.js
@@ -18,7 +18,6 @@ const {
 } = require('./lib/symbols.js');
 
 module.exports = function patchOfflineAudioContext(jsExport, nativeBinding) {
-  console.log(jsExport);
   class OfflineAudioContext extends jsExport.BaseAudioContext {
     #renderedBuffer = null;
 

--- a/js/OscillatorNode.js
+++ b/js/OscillatorNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioScheduledSourceNode = require('./AudioScheduledSourceNode.js');
@@ -139,9 +136,6 @@ module.exports = (jsExport, nativeBinding) => {
       super(context, {
         [kNapiObj]: napiObj,
       });
-
-      // Bridge Rust native event to Node EventTarget
-      bridgeEventTarget(this);
 
       this.#frequency = new jsExport.AudioParam({
         [kNapiObj]: this[kNapiObj].frequency,

--- a/js/PannerNode.js
+++ b/js/PannerNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/StereoPannerNode.js
+++ b/js/StereoPannerNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/WaveShaperNode.js
+++ b/js/WaveShaperNode.js
@@ -33,9 +33,6 @@ const {
   kNapiObj,
   kAudioBuffer,
 } = require('./lib/symbols.js');
-const {
-  bridgeEventTarget,
-} = require('./lib/events.js');
 /* eslint-enable no-unused-vars */
 
 const AudioNode = require('./AudioNode.js');

--- a/js/lib/events.js
+++ b/js/lib/events.js
@@ -1,24 +1,6 @@
 const { kNapiObj, kDispatchEvent } = require('./symbols.js');
 const { isFunction } = require('./utils.js');
 
-/**
- * Listen for events from Rust, and bridge them to Node EventTarget paradigm
- */
-module.exports.bridgeEventTarget = function bridgeEventTarget(jsObj) {
-    // Finalize event registration on Rust side
-  jsObj[kNapiObj][kDispatchEvent] = (err, eventType) => {
-    const event = new Event(eventType);
-    // call attribute first if exists
-    if (isFunction(jsObj[`on${event.type}`])) {
-      jsObj[`on${event.type}`](event);
-    }
-    // then distach to add event listeners
-    jsObj.dispatchEvent(event);
-  }
-  // ask Rust to register `kDispatchEvent` as listener
-  jsObj[kNapiObj].__initEventTarget__();
-}
-
 module.exports.propagateEvent = function propagateEvent(eventTarget, event) {
   // call attribute first if exists
   if (isFunction(eventTarget[`on${event.type}`])) {

--- a/js/lib/events.js
+++ b/js/lib/events.js
@@ -18,3 +18,12 @@ module.exports.bridgeEventTarget = function bridgeEventTarget(jsObj) {
   // ask Rust to register `kDispatchEvent` as listener
   jsObj[kNapiObj].__initEventTarget__();
 }
+
+module.exports.propagateEvent = function propagateEvent(eventTarget, event) {
+  // call attribute first if exists
+  if (isFunction(eventTarget[`on${event.type}`])) {
+    eventTarget[`on${event.type}`](event);
+  }
+  // then distach to add event listeners
+  eventTarget.dispatchEvent(event);
+}

--- a/js/lib/symbols.js
+++ b/js/lib/symbols.js
@@ -4,14 +4,15 @@ module.exports.kAudioBuffer = Symbol('node-web-audio-api:audio-buffer');
 // this needs to be shared with Rust ide
 module.exports.kDispatchEvent = Symbol.for('node-web-audio-api:napi-dispatch-event');
 
-// BaseAudioContext
+// # BaseAudioContext
 module.exports.kOnStateChange = Symbol.for('node-web-audio-api:onstatechange');
 // AudioContext
 module.exports.kOnSinkChange = Symbol.for('node-web-audio-api:onsinkchange');
-// OfflineAudioContext
-// [spec] [onstatechane] This event is fired before the complete event is fired
-// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange
+// # OfflineAudioContext
+// > [The onstatechange] event is fired before the complete event is fired
+// cf. https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange
+// @fixme: for now the `complete` event is triggered **before** startRenring fulfills
 module.exports.kOnComplete = Symbol.for('node-web-audio-api:oncomplete');
-// AudioScheduledSourceNode
+// # AudioScheduledSourceNode
 module.exports.kOnEnded = Symbol.for('node-web-audio-api:onended');
 

--- a/js/lib/symbols.js
+++ b/js/lib/symbols.js
@@ -4,8 +4,14 @@ module.exports.kAudioBuffer = Symbol('node-web-audio-api:audio-buffer');
 // this needs to be shared with Rust ide
 module.exports.kDispatchEvent = Symbol.for('node-web-audio-api:napi-dispatch-event');
 
+// BaseAudioContext
 module.exports.kOnStateChange = Symbol.for('node-web-audio-api:onstatechange');
+// AudioContext
 module.exports.kOnSinkChange = Symbol.for('node-web-audio-api:onsinkchange');
+// OfflineAudioContext
+// [spec] [onstatechane] This event is fired before the complete event is fired
+// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange
 module.exports.kOnComplete = Symbol.for('node-web-audio-api:oncomplete');
+// AudioScheduledSourceNode
 module.exports.kOnEnded = Symbol.for('node-web-audio-api:onended');
 

--- a/js/lib/symbols.js
+++ b/js/lib/symbols.js
@@ -1,5 +1,11 @@
 module.exports.kNapiObj = Symbol('node-web-audio-api:napi-obj');
 module.exports.kAudioBuffer = Symbol('node-web-audio-api:audio-buffer');
+
 // this needs to be shared with Rust ide
 module.exports.kDispatchEvent = Symbol.for('node-web-audio-api:napi-dispatch-event');
+
+module.exports.kOnStateChange = Symbol.for('node-web-audio-api:onstatechange');
+module.exports.kOnSinkChange = Symbol.for('node-web-audio-api:onsinkchange');
+module.exports.kOnComplete = Symbol.for('node-web-audio-api:oncomplete');
+module.exports.kOnEnded = Symbol.for('node-web-audio-api:onended');
 

--- a/js/monkey-patch.js
+++ b/js/monkey-patch.js
@@ -19,8 +19,13 @@
 
 module.exports = function monkeyPatch(nativeBinding) {
   let jsExport = {};
+
   // --------------------------------------------------------------------------
-  // Monkey Patch Web Audio API
+  // Events
+  // --------------------------------------------------------------------------
+  jsExport.OfflineAudioCompletionEvent = require('./Events').OfflineAudioCompletionEvent;
+  // --------------------------------------------------------------------------
+  // Create Web Audio API facade
   // --------------------------------------------------------------------------
   jsExport.BaseAudioContext = require('./BaseAudioContext.js')(jsExport, nativeBinding);
   jsExport.AudioContext = require('./AudioContext.js')(jsExport, nativeBinding);

--- a/src/analyser_node.rs
+++ b/src/analyser_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiAnalyserNode(AnalyserNode);
 
 // for debug purpose
-// impl Drop for NapiAnalyserNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiAnalyserNode dropped");
-//     }
-// }
+impl Drop for NapiAnalyserNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiAnalyserNode dropped");
+    }
+}
 
 impl NapiAnalyserNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -56,7 +56,7 @@ impl NapiAnalyserNode {
         env.define_class("AnalyserNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut AnalyserNode {
         &mut self.0
     }

--- a/src/analyser_node.rs
+++ b/src/analyser_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiAnalyserNode(AnalyserNode);
 
 // for debug purpose
-impl Drop for NapiAnalyserNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiAnalyserNode dropped");
-    }
-}
+// impl Drop for NapiAnalyserNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiAnalyserNode dropped");
+//     }
+// }
 
 impl NapiAnalyserNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiAudioBufferSourceNode(AudioBufferSourceNode);
 
 // for debug purpose
-impl Drop for NapiAudioBufferSourceNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiAudioBufferSourceNode dropped");
-    }
-}
+// impl Drop for NapiAudioBufferSourceNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiAudioBufferSourceNode dropped");
+//     }
+// }
 
 impl NapiAudioBufferSourceNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -47,8 +47,7 @@ impl NapiAudioBufferSourceNode {
                 .with_getter(get_loop_end)
                 .with_setter(set_loop_end),
             Property::new("start")?.with_method(start),
-            Property::new("stop")?.with_method(stop),
-            Property::new("clear_ended_callback")?.with_method(clear_ended_callback)
+            Property::new("stop")?.with_method(stop)
         ];
 
         env.define_class("AudioBufferSourceNode", constructor, &interface)
@@ -190,8 +189,6 @@ fn listen_to_ended_event(
     js_this: &JsObject,
     node: &mut AudioBufferSourceNode,
 ) -> Result<()> {
-    use std::sync::{Arc, Mutex};
-
     use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
     use web_audio_api::Event;
 
@@ -207,30 +204,13 @@ fn listen_to_ended_event(
         })?;
 
     // unref tsfn so they do not prevent the process to exit
-    // let _ = ended_tsfn.unref(env);
-    let ended_tsfn_mutex = Arc::new(Mutex::new(ended_tsfn.clone()));
+    let _ = ended_tsfn.unref(env);
 
     node.set_onended(move |e| {
         ended_tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-        // even with unref, if the tsfn is not aborted, the node cannot
-        // be garbage collected
-        std::thread::sleep(std::time::Duration::from_micros(100));
-        let ended_tsfn = ended_tsfn_mutex.lock().unwrap();
-        let _ = ended_tsfn.clone().abort();
     });
 
     Ok(())
-}
-
-#[js_function]
-fn clear_ended_callback(ctx: CallContext) -> Result<JsUndefined> {
-    let js_this = ctx.this_unchecked::<JsObject>();
-    let napi_node = ctx.env.unwrap::<NapiAudioBufferSourceNode>(&js_this)?;
-    let node = napi_node.unwrap();
-
-    // node.clear_onended();
-
-    ctx.env.get_undefined()
 }
 
 #[js_function(3)]

--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiAudioBufferSourceNode(AudioBufferSourceNode);
 
 // for debug purpose
-// impl Drop for NapiAudioBufferSourceNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiAudioBufferSourceNode dropped");
-//     }
-// }
+impl Drop for NapiAudioBufferSourceNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiAudioBufferSourceNode dropped");
+    }
+}
 
 impl NapiAudioBufferSourceNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -48,13 +48,13 @@ impl NapiAudioBufferSourceNode {
                 .with_setter(set_loop_end),
             Property::new("start")?.with_method(start),
             Property::new("stop")?.with_method(stop),
-            Property::new("__initEventTarget__")?.with_method(init_event_target)
+            Property::new("clear_ended_callback")?.with_method(clear_ended_callback)
         ];
 
         env.define_class("AudioBufferSourceNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut AudioBufferSourceNode {
         &mut self.0
     }
@@ -190,11 +190,61 @@ audio_node_impl!(NapiAudioBufferSourceNode);
 // -------------------------------------------------
 // AudioScheduledSourceNode Interface
 // -------------------------------------------------
+fn listen_to_ended_event(
+    env: &Env,
+    js_this: &JsObject,
+    node: &mut AudioBufferSourceNode,
+) -> Result<()> {
+    use std::sync::{Arc, Mutex};
+
+    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
+    use web_audio_api::Event;
+
+    let k_onended = get_symbol_for(env, "node-web-audio-api:onended");
+    let ended_cb = js_this.get_property(k_onended).unwrap();
+    let mut ended_tsfn =
+        env.create_threadsafe_function(&ended_cb, 0, |ctx: ThreadSafeCallContext<Event>| {
+            let mut event = ctx.env.create_object()?;
+            let event_type = ctx.env.create_string(ctx.value.type_)?;
+            event.set_named_property("type", event_type)?;
+
+            Ok(vec![event])
+        })?;
+
+    // unref tsfn so they do not prevent the process to exit
+    // let _ = ended_tsfn.unref(env);
+    let ended_tsfn_mutex = Arc::new(Mutex::new(ended_tsfn.clone()));
+
+    node.set_onended(move |e| {
+        ended_tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+        // even with unref, if the tsfn is not aborted, the node cannot
+        // be garbage collected
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let ended_tsfn = ended_tsfn_mutex.lock().unwrap();
+        let _ = ended_tsfn.clone().abort();
+    });
+
+    Ok(())
+}
+
+#[js_function]
+fn clear_ended_callback(ctx: CallContext) -> Result<JsUndefined> {
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_node = ctx.env.unwrap::<NapiAudioBufferSourceNode>(&js_this)?;
+    let node = napi_node.unwrap();
+
+    // node.clear_onended();
+
+    ctx.env.get_undefined()
+}
+
 #[js_function(3)]
 fn start(ctx: CallContext) -> Result<JsUndefined> {
     let js_this = ctx.this_unchecked::<JsObject>();
     let napi_node = ctx.env.unwrap::<NapiAudioBufferSourceNode>(&js_this)?;
     let node = napi_node.unwrap();
+
+    listen_to_ended_event(ctx.env, &js_this, node)?;
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
 
@@ -225,67 +275,6 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
     node.stop_at(when);
-
-    ctx.env.get_undefined()
-}
-
-// ----------------------------------------------------
-// EventTarget initialization - cf. js/utils/events.js
-// ----------------------------------------------------
-#[js_function]
-fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
-    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
-    use web_audio_api::Event;
-
-    let js_this = ctx.this_unchecked::<JsObject>();
-    let napi_node = ctx.env.unwrap::<NapiAudioBufferSourceNode>(&js_this)?;
-    let node = napi_node.unwrap();
-
-    // garb the napi audio context
-    let js_audio_context: JsObject = js_this.get_named_property("context")?;
-    let audio_context_name =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-    let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-    let audio_context_str = &audio_context_utf8_name[..];
-
-    let dispatch_event_symbol = ctx
-        .env
-        .symbol_for("node-web-audio-api:napi-dispatch-event")
-        .unwrap();
-    let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
-
-    let tsfn =
-        ctx.env
-            .create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-                let event_type = ctx.env.create_string(ctx.value.type_)?;
-                Ok(vec![event_type])
-            })?;
-
-    match audio_context_str {
-        "AudioContext" => {
-            let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        "OfflineAudioContext" => {
-            let napi_context = ctx
-                .env
-                .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        &_ => unreachable!(),
-    };
 
     ctx.env.get_undefined()
 }

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -38,8 +38,9 @@ impl NapiAudioContext {
             Property::new("resume")?.with_method(resume),
             Property::new("suspend")?.with_method(suspend),
             Property::new("close")?.with_method(close),
-            // [non spec] workaround to listen for `sinkchange` and `statechange` events
-            // This must be called from JS ctor as we don't have an initial `resume` call
+            // Workaround to bind the `sinkchange` and `statechange` events to EventTarget.
+            // This must be called from JS facade ctor as the JS handler are added to the Napi
+            // object after its instantiation, and that we don't have any initial `resume` call.
             Property::new("listen_to_events")?.with_method(listen_to_events)
         ];
 

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -51,6 +51,7 @@ impl NapiAudioContext {
         &self.context
     }
 
+    #[allow(dead_code)]
     pub fn store_thread_safe_listener(&self, tsfn: ThreadsafeFunction<Event>) -> String {
         let mut tsfn_store = self.tsfn_store.lock().unwrap();
         let uuid = Uuid::new_v4();
@@ -62,6 +63,7 @@ impl NapiAudioContext {
     // We need to clean things around so that the js object can be garbage collected.
     // But we also need to wait so that the previous tsfn.call is executed.
     // This is not clean, but don't see how to implement that properly right now.
+    #[allow(dead_code)]
     pub fn clear_thread_safe_listener(&self, store_id: String) {
         std::thread::sleep(std::time::Duration::from_millis(1));
         let mut tsfn_store = self.tsfn_store.lock().unwrap();

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -70,6 +70,7 @@ impl NapiAudioContext {
         }
     }
 
+    #[allow(dead_code)]
     pub fn clear_all_thread_safe_listeners(&self) {
         std::thread::sleep(std::time::Duration::from_millis(1));
         let mut tsfn_store = self.tsfn_store.lock().unwrap();

--- a/src/base_audio_context.rs
+++ b/src/base_audio_context.rs
@@ -78,7 +78,7 @@ macro_rules! base_audio_context_impl {
         fn decode_audio_data(ctx: CallContext) -> Result<JsObject> {
             let js_this = ctx.this_unchecked::<JsObject>();
             let napi_obj = ctx.env.unwrap::<$napi_struct>(&js_this)?;
-            let clone = Arc::clone(&napi_obj.context);
+            let clone = Arc::clone(&napi_obj.0);
 
             let js_buffer = ctx.get::<JsArrayBuffer>(0)?.into_value()?;
             let cursor = Cursor::new(js_buffer.to_vec());

--- a/src/biquad_filter_node.rs
+++ b/src/biquad_filter_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiBiquadFilterNode(BiquadFilterNode);
 
 // for debug purpose
-// impl Drop for NapiBiquadFilterNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiBiquadFilterNode dropped");
-//     }
-// }
+impl Drop for NapiBiquadFilterNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiBiquadFilterNode dropped");
+    }
+}
 
 impl NapiBiquadFilterNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -43,7 +43,7 @@ impl NapiBiquadFilterNode {
         env.define_class("BiquadFilterNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut BiquadFilterNode {
         &mut self.0
     }

--- a/src/biquad_filter_node.rs
+++ b/src/biquad_filter_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiBiquadFilterNode(BiquadFilterNode);
 
 // for debug purpose
-impl Drop for NapiBiquadFilterNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiBiquadFilterNode dropped");
-    }
-}
+// impl Drop for NapiBiquadFilterNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiBiquadFilterNode dropped");
+//     }
+// }
 
 impl NapiBiquadFilterNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/channel_merger_node.rs
+++ b/src/channel_merger_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiChannelMergerNode(ChannelMergerNode);
 
 // for debug purpose
-// impl Drop for NapiChannelMergerNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiChannelMergerNode dropped");
-//     }
-// }
+impl Drop for NapiChannelMergerNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiChannelMergerNode dropped");
+    }
+}
 
 impl NapiChannelMergerNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -38,7 +38,7 @@ impl NapiChannelMergerNode {
         env.define_class("ChannelMergerNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut ChannelMergerNode {
         &mut self.0
     }

--- a/src/channel_merger_node.rs
+++ b/src/channel_merger_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiChannelMergerNode(ChannelMergerNode);
 
 // for debug purpose
-impl Drop for NapiChannelMergerNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiChannelMergerNode dropped");
-    }
-}
+// impl Drop for NapiChannelMergerNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiChannelMergerNode dropped");
+//     }
+// }
 
 impl NapiChannelMergerNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/channel_splitter_node.rs
+++ b/src/channel_splitter_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiChannelSplitterNode(ChannelSplitterNode);
 
 // for debug purpose
-// impl Drop for NapiChannelSplitterNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiChannelSplitterNode dropped");
-//     }
-// }
+impl Drop for NapiChannelSplitterNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiChannelSplitterNode dropped");
+    }
+}
 
 impl NapiChannelSplitterNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -38,7 +38,7 @@ impl NapiChannelSplitterNode {
         env.define_class("ChannelSplitterNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut ChannelSplitterNode {
         &mut self.0
     }

--- a/src/channel_splitter_node.rs
+++ b/src/channel_splitter_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiChannelSplitterNode(ChannelSplitterNode);
 
 // for debug purpose
-impl Drop for NapiChannelSplitterNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiChannelSplitterNode dropped");
-    }
-}
+// impl Drop for NapiChannelSplitterNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiChannelSplitterNode dropped");
+//     }
+// }
 
 impl NapiChannelSplitterNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/constant_source_node.rs
+++ b/src/constant_source_node.rs
@@ -25,24 +25,24 @@ use web_audio_api::node::*;
 pub(crate) struct NapiConstantSourceNode(ConstantSourceNode);
 
 // for debug purpose
-// impl Drop for NapiConstantSourceNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiConstantSourceNode dropped");
-//     }
-// }
+impl Drop for NapiConstantSourceNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiConstantSourceNode dropped");
+    }
+}
 
 impl NapiConstantSourceNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
         let interface = audio_node_interface![
             Property::new("start")?.with_method(start),
             Property::new("stop")?.with_method(stop),
-            Property::new("__initEventTarget__")?.with_method(init_event_target)
+            Property::new("clear_ended_callback")?.with_method(clear_ended_callback)
         ];
 
         env.define_class("ConstantSourceNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut ConstantSourceNode {
         &mut self.0
     }
@@ -133,11 +133,61 @@ audio_node_impl!(NapiConstantSourceNode);
 // -------------------------------------------------
 // AudioScheduledSourceNode Interface
 // -------------------------------------------------
+fn listen_to_ended_event(
+    env: &Env,
+    js_this: &JsObject,
+    node: &mut ConstantSourceNode,
+) -> Result<()> {
+    use std::sync::{Arc, Mutex};
+
+    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
+    use web_audio_api::Event;
+
+    let k_onended = get_symbol_for(env, "node-web-audio-api:onended");
+    let ended_cb = js_this.get_property(k_onended).unwrap();
+    let mut ended_tsfn =
+        env.create_threadsafe_function(&ended_cb, 0, |ctx: ThreadSafeCallContext<Event>| {
+            let mut event = ctx.env.create_object()?;
+            let event_type = ctx.env.create_string(ctx.value.type_)?;
+            event.set_named_property("type", event_type)?;
+
+            Ok(vec![event])
+        })?;
+
+    // unref tsfn so they do not prevent the process to exit
+    // let _ = ended_tsfn.unref(env);
+    let ended_tsfn_mutex = Arc::new(Mutex::new(ended_tsfn.clone()));
+
+    node.set_onended(move |e| {
+        ended_tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+        // even with unref, if the tsfn is not aborted, the node cannot
+        // be garbage collected
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let ended_tsfn = ended_tsfn_mutex.lock().unwrap();
+        let _ = ended_tsfn.clone().abort();
+    });
+
+    Ok(())
+}
+
+#[js_function]
+fn clear_ended_callback(ctx: CallContext) -> Result<JsUndefined> {
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_node = ctx.env.unwrap::<NapiConstantSourceNode>(&js_this)?;
+    let node = napi_node.unwrap();
+
+    // node.clear_onended();
+
+    ctx.env.get_undefined()
+}
+
 #[js_function(1)]
 fn start(ctx: CallContext) -> Result<JsUndefined> {
     let js_this = ctx.this_unchecked::<JsObject>();
     let napi_node = ctx.env.unwrap::<NapiConstantSourceNode>(&js_this)?;
     let node = napi_node.unwrap();
+
+    listen_to_ended_event(ctx.env, &js_this, node)?;
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
     node.start_at(when);
@@ -153,67 +203,6 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
     node.stop_at(when);
-
-    ctx.env.get_undefined()
-}
-
-// ----------------------------------------------------
-// EventTarget initialization - cf. js/utils/events.js
-// ----------------------------------------------------
-#[js_function]
-fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
-    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
-    use web_audio_api::Event;
-
-    let js_this = ctx.this_unchecked::<JsObject>();
-    let napi_node = ctx.env.unwrap::<NapiConstantSourceNode>(&js_this)?;
-    let node = napi_node.unwrap();
-
-    // garb the napi audio context
-    let js_audio_context: JsObject = js_this.get_named_property("context")?;
-    let audio_context_name =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-    let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-    let audio_context_str = &audio_context_utf8_name[..];
-
-    let dispatch_event_symbol = ctx
-        .env
-        .symbol_for("node-web-audio-api:napi-dispatch-event")
-        .unwrap();
-    let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
-
-    let tsfn =
-        ctx.env
-            .create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-                let event_type = ctx.env.create_string(ctx.value.type_)?;
-                Ok(vec![event_type])
-            })?;
-
-    match audio_context_str {
-        "AudioContext" => {
-            let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        "OfflineAudioContext" => {
-            let napi_context = ctx
-                .env
-                .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        &_ => unreachable!(),
-    };
 
     ctx.env.get_undefined()
 }

--- a/src/convolver_node.rs
+++ b/src/convolver_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiConvolverNode(ConvolverNode);
 
 // for debug purpose
-// impl Drop for NapiConvolverNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiConvolverNode dropped");
-//     }
-// }
+impl Drop for NapiConvolverNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiConvolverNode dropped");
+    }
+}
 
 impl NapiConvolverNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -45,7 +45,7 @@ impl NapiConvolverNode {
         env.define_class("ConvolverNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut ConvolverNode {
         &mut self.0
     }

--- a/src/convolver_node.rs
+++ b/src/convolver_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiConvolverNode(ConvolverNode);
 
 // for debug purpose
-impl Drop for NapiConvolverNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiConvolverNode dropped");
-    }
-}
+// impl Drop for NapiConvolverNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiConvolverNode dropped");
+//     }
+// }
 
 impl NapiConvolverNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/delay_node.rs
+++ b/src/delay_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiDelayNode(DelayNode);
 
 // for debug purpose
-impl Drop for NapiDelayNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiDelayNode dropped");
-    }
-}
+// impl Drop for NapiDelayNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiDelayNode dropped");
+//     }
+// }
 
 impl NapiDelayNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/delay_node.rs
+++ b/src/delay_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiDelayNode(DelayNode);
 
 // for debug purpose
-// impl Drop for NapiDelayNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiDelayNode dropped");
-//     }
-// }
+impl Drop for NapiDelayNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiDelayNode dropped");
+    }
+}
 
 impl NapiDelayNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -38,7 +38,7 @@ impl NapiDelayNode {
         env.define_class("DelayNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut DelayNode {
         &mut self.0
     }

--- a/src/dynamics_compressor_node.rs
+++ b/src/dynamics_compressor_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiDynamicsCompressorNode(DynamicsCompressorNode);
 
 // for debug purpose
-impl Drop for NapiDynamicsCompressorNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiDynamicsCompressorNode dropped");
-    }
-}
+// impl Drop for NapiDynamicsCompressorNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiDynamicsCompressorNode dropped");
+//     }
+// }
 
 impl NapiDynamicsCompressorNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/dynamics_compressor_node.rs
+++ b/src/dynamics_compressor_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiDynamicsCompressorNode(DynamicsCompressorNode);
 
 // for debug purpose
-// impl Drop for NapiDynamicsCompressorNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiDynamicsCompressorNode dropped");
-//     }
-// }
+impl Drop for NapiDynamicsCompressorNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiDynamicsCompressorNode dropped");
+    }
+}
 
 impl NapiDynamicsCompressorNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -39,7 +39,7 @@ impl NapiDynamicsCompressorNode {
         env.define_class("DynamicsCompressorNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut DynamicsCompressorNode {
         &mut self.0
     }

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiGainNode(GainNode);
 
 // for debug purpose
-// impl Drop for NapiGainNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiGainNode dropped");
-//     }
-// }
+impl Drop for NapiGainNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiGainNode dropped");
+    }
+}
 
 impl NapiGainNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -38,7 +38,7 @@ impl NapiGainNode {
         env.define_class("GainNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut GainNode {
         &mut self.0
     }

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiGainNode(GainNode);
 
 // for debug purpose
-impl Drop for NapiGainNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiGainNode dropped");
-    }
-}
+// impl Drop for NapiGainNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiGainNode dropped");
+//     }
+// }
 
 impl NapiGainNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/iir_filter_node.rs
+++ b/src/iir_filter_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiIIRFilterNode(IIRFilterNode);
 
 // for debug purpose
-impl Drop for NapiIIRFilterNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiIIRFilterNode dropped");
-    }
-}
+// impl Drop for NapiIIRFilterNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiIIRFilterNode dropped");
+//     }
+// }
 
 impl NapiIIRFilterNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/iir_filter_node.rs
+++ b/src/iir_filter_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiIIRFilterNode(IIRFilterNode);
 
 // for debug purpose
-// impl Drop for NapiIIRFilterNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiIIRFilterNode dropped");
-//     }
-// }
+impl Drop for NapiIIRFilterNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiIIRFilterNode dropped");
+    }
+}
 
 impl NapiIIRFilterNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -40,7 +40,7 @@ impl NapiIIRFilterNode {
         env.define_class("IIRFilterNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut IIRFilterNode {
         &mut self.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 
 #![deny(clippy::all)]
 
-use napi::{Env, JsObject, JsSymbol, Result};
+use napi::{Env, JsFunction, JsObject, JsSymbol, Result};
 use napi_derive::module_exports;
 
 // cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
@@ -30,6 +30,13 @@ pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {
 
 pub(crate) fn get_symbol_for(env: &Env, name: &str) -> JsSymbol {
     env.symbol_for(name).unwrap()
+}
+
+pub(crate) fn get_class_ctor(env: &Env, name: &str) -> Result<JsFunction> {
+    let store_ref: &mut napi::Ref<()> = env.get_instance_data()?.unwrap();
+    let store: JsObject = env.get_reference_value(store_ref)?;
+    let ctor: JsFunction = store.get_named_property(name)?;
+    Ok(ctor)
 }
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,17 @@
 
 #![deny(clippy::all)]
 
-use napi::{Env, JsObject, Result};
+use napi::{Env, JsObject, JsSymbol, Result};
 use napi_derive::module_exports;
 
 // cf. https://users.rust-lang.org/t/vec-f32-to-u8/21522/7
 #[allow(clippy::needless_lifetimes)]
 pub(crate) fn to_byte_slice<'a>(floats: &'a [f32]) -> &'a [u8] {
     unsafe { std::slice::from_raw_parts(floats.as_ptr() as *const _, floats.len() * 4) }
+}
+
+pub(crate) fn get_symbol_for(env: &Env, name: &str) -> JsSymbol {
+    env.symbol_for(name).unwrap()
 }
 
 #[macro_use]

--- a/src/media_stream_audio_source_node.rs
+++ b/src/media_stream_audio_source_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiMediaStreamAudioSourceNode(MediaStreamAudioSourceNode);
 
 // for debug purpose
-impl Drop for NapiMediaStreamAudioSourceNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiMediaStreamAudioSourceNode dropped");
-    }
-}
+// impl Drop for NapiMediaStreamAudioSourceNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiMediaStreamAudioSourceNode dropped");
+//     }
+// }
 
 impl NapiMediaStreamAudioSourceNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/media_stream_audio_source_node.rs
+++ b/src/media_stream_audio_source_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiMediaStreamAudioSourceNode(MediaStreamAudioSourceNode);
 
 // for debug purpose
-// impl Drop for NapiMediaStreamAudioSourceNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiMediaStreamAudioSourceNode dropped");
-//     }
-// }
+impl Drop for NapiMediaStreamAudioSourceNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiMediaStreamAudioSourceNode dropped");
+    }
+}
 
 impl NapiMediaStreamAudioSourceNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -38,7 +38,7 @@ impl NapiMediaStreamAudioSourceNode {
         env.define_class("MediaStreamAudioSourceNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut MediaStreamAudioSourceNode {
         &mut self.0
     }

--- a/src/offline_audio_context.rs
+++ b/src/offline_audio_context.rs
@@ -1,25 +1,16 @@
-use std::collections::HashMap;
 use std::io::Cursor;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use napi::threadsafe_function::{
-    ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
-};
+use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
 use napi::*;
 use napi_derive::js_function;
-use uuid::Uuid;
 use web_audio_api::context::*;
 use web_audio_api::{Event, OfflineAudioCompletionEvent};
 
 use crate::*;
 
 #[derive(Clone)]
-pub(crate) struct NapiOfflineAudioContext {
-    context: Arc<OfflineAudioContext>,
-    // store all ThreadsafeFunction created for listening to events
-    // so that they can be aborted when the context is closed
-    tsfn_store: Arc<Mutex<HashMap<String, ThreadsafeFunction<Event>>>>,
-}
+pub(crate) struct NapiOfflineAudioContext(Arc<OfflineAudioContext>);
 
 // for debug purpose
 // impl Drop for NapiOfflineAudioContext {
@@ -41,39 +32,7 @@ impl NapiOfflineAudioContext {
     }
 
     pub fn unwrap(&self) -> &OfflineAudioContext {
-        &self.context
-    }
-
-    #[allow(dead_code)]
-    pub fn store_thread_safe_listener(&self, tsfn: ThreadsafeFunction<Event>) -> String {
-        let mut tsfn_store = self.tsfn_store.lock().unwrap();
-        let uuid = Uuid::new_v4();
-        tsfn_store.insert(uuid.to_string(), tsfn);
-
-        uuid.to_string()
-    }
-
-    // We need to clean things around so that the js object can be garbage collected.
-    // But we also need to wait so that the previous tsfn.call is executed.
-    // This is not clean, but don't see how to implement that properly right now.
-    #[allow(dead_code)]
-    pub fn clear_thread_safe_listener(&self, store_id: String) {
-        std::thread::sleep(std::time::Duration::from_millis(1));
-        let mut tsfn_store = self.tsfn_store.lock().unwrap();
-
-        if let Some(tsfn) = tsfn_store.remove(&store_id) {
-            let _ = tsfn.abort();
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn clear_all_thread_safe_listeners(&self) {
-        std::thread::sleep(std::time::Duration::from_millis(1));
-        let mut tsfn_store = self.tsfn_store.lock().unwrap();
-
-        for (_, tsfn) in tsfn_store.drain() {
-            let _ = tsfn.abort();
-        }
+        &self.0
     }
 }
 
@@ -93,10 +52,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     // -------------------------------------------------
     // Wrap context
     // -------------------------------------------------
-    let napi_audio_context = NapiOfflineAudioContext {
-        context: Arc::new(audio_context),
-        tsfn_store: Arc::new(HashMap::new().into()),
-    };
+    let napi_audio_context = NapiOfflineAudioContext(Arc::new(audio_context));
     ctx.env.wrap(&mut js_this, napi_audio_context)?;
 
     js_this.define_properties(&[
@@ -189,7 +145,7 @@ fn start_rendering(ctx: CallContext) -> Result<JsObject> {
     });
 
     // everything is setup, do "real" rendering job
-    let context_clone = Arc::clone(&napi_context.context);
+    let context_clone = Arc::clone(&napi_context.0);
 
     ctx.env.execute_tokio_future(
         async move {
@@ -211,12 +167,12 @@ fn start_rendering(ctx: CallContext) -> Result<JsObject> {
 #[js_function]
 fn resume(ctx: CallContext) -> Result<JsObject> {
     let js_this = ctx.this_unchecked::<JsObject>();
-    let napi_obj = ctx.env.unwrap::<NapiOfflineAudioContext>(&js_this)?;
-    let clone = Arc::clone(&napi_obj.context);
+    let napi_context = ctx.env.unwrap::<NapiOfflineAudioContext>(&js_this)?;
+    let context_clone = Arc::clone(&napi_context.0);
 
     ctx.env.execute_tokio_future(
         async move {
-            clone.resume().await;
+            context_clone.resume().await;
             Ok(())
         },
         |&mut env, _val| env.get_undefined(),
@@ -226,14 +182,14 @@ fn resume(ctx: CallContext) -> Result<JsObject> {
 #[js_function(1)]
 fn suspend(ctx: CallContext) -> Result<JsObject> {
     let js_this = ctx.this_unchecked::<JsObject>();
-    let napi_obj = ctx.env.unwrap::<NapiOfflineAudioContext>(&js_this)?;
-    let clone = Arc::clone(&napi_obj.context);
+    let napi_context = ctx.env.unwrap::<NapiOfflineAudioContext>(&js_this)?;
+    let context_clone = Arc::clone(&napi_context.0);
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
 
     ctx.env.execute_tokio_future(
         async move {
-            clone.suspend(when).await;
+            context_clone.suspend(when).await;
             Ok(())
         },
         |&mut env, _val| env.get_undefined(),

--- a/src/offline_audio_context.rs
+++ b/src/offline_audio_context.rs
@@ -44,6 +44,7 @@ impl NapiOfflineAudioContext {
         &self.context
     }
 
+    #[allow(dead_code)]
     pub fn store_thread_safe_listener(&self, tsfn: ThreadsafeFunction<Event>) -> String {
         let mut tsfn_store = self.tsfn_store.lock().unwrap();
         let uuid = Uuid::new_v4();
@@ -55,6 +56,7 @@ impl NapiOfflineAudioContext {
     // We need to clean things around so that the js object can be garbage collected.
     // But we also need to wait so that the previous tsfn.call is executed.
     // This is not clean, but don't see how to implement that properly right now.
+    #[allow(dead_code)]
     pub fn clear_thread_safe_listener(&self, store_id: String) {
         std::thread::sleep(std::time::Duration::from_millis(1));
         let mut tsfn_store = self.tsfn_store.lock().unwrap();

--- a/src/oscillator_node.rs
+++ b/src/oscillator_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiOscillatorNode(OscillatorNode);
 
 // for debug purpose
-// impl Drop for NapiOscillatorNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiOscillatorNode dropped");
-//     }
-// }
+impl Drop for NapiOscillatorNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiOscillatorNode dropped");
+    }
+}
 
 impl NapiOscillatorNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -40,13 +40,13 @@ impl NapiOscillatorNode {
             Property::new("setPeriodicWave")?.with_method(set_periodic_wave),
             Property::new("start")?.with_method(start),
             Property::new("stop")?.with_method(stop),
-            Property::new("__initEventTarget__")?.with_method(init_event_target)
+            Property::new("clear_ended_callback")?.with_method(clear_ended_callback)
         ];
 
         env.define_class("OscillatorNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut OscillatorNode {
         &mut self.0
     }
@@ -230,11 +230,57 @@ audio_node_impl!(NapiOscillatorNode);
 // -------------------------------------------------
 // AudioScheduledSourceNode Interface
 // -------------------------------------------------
+fn listen_to_ended_event(env: &Env, js_this: &JsObject, node: &mut OscillatorNode) -> Result<()> {
+    use std::sync::{Arc, Mutex};
+
+    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
+    use web_audio_api::Event;
+
+    let k_onended = get_symbol_for(env, "node-web-audio-api:onended");
+    let ended_cb = js_this.get_property(k_onended).unwrap();
+    let mut ended_tsfn =
+        env.create_threadsafe_function(&ended_cb, 0, |ctx: ThreadSafeCallContext<Event>| {
+            let mut event = ctx.env.create_object()?;
+            let event_type = ctx.env.create_string(ctx.value.type_)?;
+            event.set_named_property("type", event_type)?;
+
+            Ok(vec![event])
+        })?;
+
+    // unref tsfn so they do not prevent the process to exit
+    // let _ = ended_tsfn.unref(env);
+    let ended_tsfn_mutex = Arc::new(Mutex::new(ended_tsfn.clone()));
+
+    node.set_onended(move |e| {
+        ended_tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
+        // even with unref, if the tsfn is not aborted, the node cannot
+        // be garbage collected
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let ended_tsfn = ended_tsfn_mutex.lock().unwrap();
+        let _ = ended_tsfn.clone().abort();
+    });
+
+    Ok(())
+}
+
+#[js_function]
+fn clear_ended_callback(ctx: CallContext) -> Result<JsUndefined> {
+    let js_this = ctx.this_unchecked::<JsObject>();
+    let napi_node = ctx.env.unwrap::<NapiOscillatorNode>(&js_this)?;
+    let node = napi_node.unwrap();
+
+    // node.clear_onended();
+
+    ctx.env.get_undefined()
+}
+
 #[js_function(1)]
 fn start(ctx: CallContext) -> Result<JsUndefined> {
     let js_this = ctx.this_unchecked::<JsObject>();
     let napi_node = ctx.env.unwrap::<NapiOscillatorNode>(&js_this)?;
     let node = napi_node.unwrap();
+
+    listen_to_ended_event(ctx.env, &js_this, node)?;
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
     node.start_at(when);
@@ -250,67 +296,6 @@ fn stop(ctx: CallContext) -> Result<JsUndefined> {
 
     let when = ctx.get::<JsNumber>(0)?.get_double()?;
     node.stop_at(when);
-
-    ctx.env.get_undefined()
-}
-
-// ----------------------------------------------------
-// EventTarget initialization - cf. js/utils/events.js
-// ----------------------------------------------------
-#[js_function]
-fn init_event_target(ctx: CallContext) -> Result<JsUndefined> {
-    use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
-    use web_audio_api::Event;
-
-    let js_this = ctx.this_unchecked::<JsObject>();
-    let napi_node = ctx.env.unwrap::<NapiOscillatorNode>(&js_this)?;
-    let node = napi_node.unwrap();
-
-    // garb the napi audio context
-    let js_audio_context: JsObject = js_this.get_named_property("context")?;
-    let audio_context_name =
-        js_audio_context.get_named_property::<JsString>("Symbol.toStringTag")?;
-    let audio_context_utf8_name = audio_context_name.into_utf8()?.into_owned()?;
-    let audio_context_str = &audio_context_utf8_name[..];
-
-    let dispatch_event_symbol = ctx
-        .env
-        .symbol_for("node-web-audio-api:napi-dispatch-event")
-        .unwrap();
-    let js_func = js_this.get_property(dispatch_event_symbol).unwrap();
-
-    let tsfn =
-        ctx.env
-            .create_threadsafe_function(&js_func, 0, |ctx: ThreadSafeCallContext<Event>| {
-                let event_type = ctx.env.create_string(ctx.value.type_)?;
-                Ok(vec![event_type])
-            })?;
-
-    match audio_context_str {
-        "AudioContext" => {
-            let napi_context = ctx.env.unwrap::<NapiAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        "OfflineAudioContext" => {
-            let napi_context = ctx
-                .env
-                .unwrap::<NapiOfflineAudioContext>(&js_audio_context)?;
-            let store_id = napi_context.store_thread_safe_listener(tsfn.clone());
-            let napi_context = napi_context.clone();
-
-            node.set_onended(move |e| {
-                tsfn.call(Ok(e), ThreadsafeFunctionCallMode::Blocking);
-                napi_context.clear_thread_safe_listener(store_id);
-            });
-        }
-        &_ => unreachable!(),
-    };
 
     ctx.env.get_undefined()
 }

--- a/src/panner_node.rs
+++ b/src/panner_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiPannerNode(PannerNode);
 
 // for debug purpose
-// impl Drop for NapiPannerNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiPannerNode dropped");
-//     }
-// }
+impl Drop for NapiPannerNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiPannerNode dropped");
+    }
+}
 
 impl NapiPannerNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -65,7 +65,7 @@ impl NapiPannerNode {
         env.define_class("PannerNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut PannerNode {
         &mut self.0
     }

--- a/src/panner_node.rs
+++ b/src/panner_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiPannerNode(PannerNode);
 
 // for debug purpose
-impl Drop for NapiPannerNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiPannerNode dropped");
-    }
-}
+// impl Drop for NapiPannerNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiPannerNode dropped");
+//     }
+// }
 
 impl NapiPannerNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/stereo_panner_node.rs
+++ b/src/stereo_panner_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiStereoPannerNode(StereoPannerNode);
 
 // for debug purpose
-impl Drop for NapiStereoPannerNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiStereoPannerNode dropped");
-    }
-}
+// impl Drop for NapiStereoPannerNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiStereoPannerNode dropped");
+//     }
+// }
 
 impl NapiStereoPannerNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/stereo_panner_node.rs
+++ b/src/stereo_panner_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiStereoPannerNode(StereoPannerNode);
 
 // for debug purpose
-// impl Drop for NapiStereoPannerNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiStereoPannerNode dropped");
-//     }
-// }
+impl Drop for NapiStereoPannerNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiStereoPannerNode dropped");
+    }
+}
 
 impl NapiStereoPannerNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -38,7 +38,7 @@ impl NapiStereoPannerNode {
         env.define_class("StereoPannerNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut StereoPannerNode {
         &mut self.0
     }

--- a/src/wave_shaper_node.rs
+++ b/src/wave_shaper_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiWaveShaperNode(WaveShaperNode);
 
 // for debug purpose
-impl Drop for NapiWaveShaperNode {
-    fn drop(&mut self) {
-        println!("NAPI: NapiWaveShaperNode dropped");
-    }
-}
+// impl Drop for NapiWaveShaperNode {
+//     fn drop(&mut self) {
+//         println!("NAPI: NapiWaveShaperNode dropped");
+//     }
+// }
 
 impl NapiWaveShaperNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {

--- a/src/wave_shaper_node.rs
+++ b/src/wave_shaper_node.rs
@@ -25,11 +25,11 @@ use web_audio_api::node::*;
 pub(crate) struct NapiWaveShaperNode(WaveShaperNode);
 
 // for debug purpose
-// impl Drop for NapiWaveShaperNode {
-//     fn drop(&mut self) {
-//         println!("NAPI: NapiWaveShaperNode dropped");
-//     }
-// }
+impl Drop for NapiWaveShaperNode {
+    fn drop(&mut self) {
+        println!("NAPI: NapiWaveShaperNode dropped");
+    }
+}
 
 impl NapiWaveShaperNode {
     pub fn create_js_class(env: &Env) -> Result<JsFunction> {
@@ -45,7 +45,7 @@ impl NapiWaveShaperNode {
         env.define_class("WaveShaperNode", constructor, &interface)
     }
 
-    // @note: this is also used in audio_node.tmpl.rs for the connect / disconnect macros
+    // @note: this is used in audio_node.rs for the connect / disconnect macros
     pub fn unwrap(&mut self) -> &mut WaveShaperNode {
         &mut self.0
     }

--- a/tests/OfflineAudioContext.spec.mjs
+++ b/tests/OfflineAudioContext.spec.mjs
@@ -1,0 +1,32 @@
+import { assert } from 'chai';
+import {
+  AudioContext,
+  OfflineAudioContext,
+} from '../index.mjs';
+
+describe('# OfflineAudioContext', () => {
+  describe('## await startRendering()', () => {
+    it('buffer returned by startRedring and buffer from complete should be same instance', async () => {
+      const offline = new OfflineAudioContext(1, 48000, 48000);
+
+      let aResult = null;
+      let bResult = null;
+
+      offline.addEventListener('complete', (e) => aResult = e.renderedBuffer);
+
+      const osc = offline.createOscillator();
+      osc.connect(offline.destination);
+      osc.frequency.value = 220;
+      osc.start(0.);
+      osc.stop(1.);
+
+      bResult = await offline.startRendering();
+      // make sure we received the event
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      assert.deepEqual(aResult, bResult);
+    });
+  });
+});
+
+


### PR DESCRIPTION
Cleaner alternative compared to #113, can basically end up with removing the ThreadsafeFunction store

Pretty happy with that so far (no more `std::thread::sleep(std::time::Duration::from_millis(1));`), let's see where it goes...