### PR TITLE
Feat - Use buffer pool in `AudioWorkletGlobalScope`

### DIFF
--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -129,6 +129,9 @@ const filter = (name) => {
     // somehow crahshes the-constantsourcenode-interface/constant-source-basic.html test
     // npm run wpt:only -- --filter the-channelmergernode-interface/active-processing.https.html the-constantsourcenode-interface/constant-source-basic.html
     || name.includes('the-channelmergernode-interface/active-processing.https.html')
+    // timeout, but when test is fixed, trigger a segfault
+    // should be fixed with https://nodejs.org/api/worker_threads.html#workermarkasuntransferableobject
+    || name.includes('the-audioworklet-interface/audioworkletprocessor-process-frozen-array.https.html')
   ) {
     return false;
   }

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -42,7 +42,7 @@ const rootURL = 'webaudio';
 // wpt tests are all run in the same process, but some tests using AudioContext
 // do not explicitely call the `close` method. As setup is called before each test
 // file we emit a global event so that AudioContext created in previous test file
-// can properly close themselves. This prevents them to pile up, continue running
+// can properly close themselves. This prevents them to pile up, continue running,
 // create all sorts of problems and waste CPU
 process.WPT_TEST_RUNNER = new EventEmitter();
 
@@ -130,9 +130,6 @@ const filter = (name) => {
     // somehow crahshes the-constantsourcenode-interface/constant-source-basic.html test
     // npm run wpt:only -- --filter the-channelmergernode-interface/active-processing.https.html the-constantsourcenode-interface/constant-source-basic.html
     || name.includes('the-channelmergernode-interface/active-processing.https.html')
-    // timeout, but when test is fixed, trigger a segfault
-    // should be fixed with https://nodejs.org/api/worker_threads.html#workermarkasuntransferableobject
-    || name.includes('the-audioworklet-interface/audioworkletprocessor-process-frozen-array.https.html')
   ) {
     return false;
   }

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -41,8 +41,9 @@ const rootURL = 'webaudio';
 
 // wpt tests are all run in the same process, but some tests using AudioContext
 // do not explicitely call the `close` method. As setup is called before each test
-// file we emit a glbal event so that AudioContext created in previous test file
-// can close themselves. This prevents them to pile up and waste CPU
+// file we emit a global event so that AudioContext created in previous test file
+// can properly close themselves. This prevents them to pile up, continue running
+// create all sorts of problems and waste CPU
 process.WPT_TEST_RUNNER = new EventEmitter();
 
 // monkey patch `window` with our web audio API

--- a/.scripts/wpt-harness.mjs
+++ b/.scripts/wpt-harness.mjs
@@ -127,9 +127,6 @@ const filter = (name) => {
   if (
      // timeouts
     name.includes('the-audiocontext-interface/suspend-with-navigation.html')
-    // somehow crahshes the-constantsourcenode-interface/constant-source-basic.html test
-    // npm run wpt:only -- --filter the-channelmergernode-interface/active-processing.https.html the-constantsourcenode-interface/constant-source-basic.html
-    || name.includes('the-channelmergernode-interface/active-processing.https.html')
   ) {
     return false;
   }

--- a/js/AudioContext.js
+++ b/js/AudioContext.js
@@ -117,7 +117,6 @@ module.exports = function(jsExport, nativeBinding) {
       });
       // keep process awake until context is closed
       const keepAwakeId = setInterval(() => {}, 10 * 1000);
-
       // clear on close
       this.addEventListener('statechange', () => {
         if (this.state === 'closed') {
@@ -126,6 +125,11 @@ module.exports = function(jsExport, nativeBinding) {
           clearTimeout(keepAwakeId);
         }
       });
+
+      // for wpt tests, see ./.scripts/wpt_harness.mjs for informations
+      if (process.WPT_TEST_RUNNER) {
+        process.WPT_TEST_RUNNER.once('cleanup', () => this.close());
+      }
     }
 
     get baseLatency() {

--- a/js/AudioWorklet.js
+++ b/js/AudioWorklet.js
@@ -134,6 +134,14 @@ class AudioWorklet {
           resolve();
           break;
         }
+        case 'node-web-audio-api:worklet:add-module-failed': {
+          const { promiseId, ctor, name, message } = event;
+          const { reject } = this.#idPromiseMap.get(promiseId);
+          this.#idPromiseMap.delete(promiseId);
+          const err = new globalThis[ctor](message, name);
+          reject(err);
+          break;
+        }
         case 'node-web-audio-api:worlet:processor-registered': {
           const { name, parameterDescriptors } = event;
           this.#workletParamDescriptorsMap.set(name, parameterDescriptors);
@@ -188,7 +196,6 @@ class AudioWorklet {
   // For OfflineAudioContext only, check that all processors have been properly
   // created before actual `startRendering`
   async [kCheckProcessorsCreated]() {
-    // console.log(this.#pendingCreateProcessors);
     return new Promise(async resolve => {
       while (this.#pendingCreateProcessors.size !== 0) {
         // we need a microtask to ensure message can be received

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -315,13 +315,23 @@ parentPort.on('message', event => {
     case 'node-web-audio-api:worklet:add-module': {
       const { code, promiseId } = event;
       const func = new Function('AudioWorkletProcessor', 'registerProcessor', code);
-      func(AudioWorkletProcessor, registerProcessor);
 
-      // send registered param descriptors on main thread and resolve Promise
-      parentPort.postMessage({
-        cmd: 'node-web-audio-api:worklet:module-added',
-        promiseId,
-      });
+      try {
+        func(AudioWorkletProcessor, registerProcessor);
+        // send registered param descriptors on main thread and resolve Promise
+        parentPort.postMessage({
+          cmd: 'node-web-audio-api:worklet:module-added',
+          promiseId,
+        });
+      } catch (err) {
+        parentPort.postMessage({
+          cmd: 'node-web-audio-api:worklet:add-module-failed',
+          promiseId,
+          ctor: err.constructor.name,
+          name: err.name,
+          message: err.message,
+        });
+      }
       break;
     }
     case 'node-web-audio-api:worklet:create-processor': {

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -234,13 +234,11 @@ globalThis.registerProcessor = function registerProcessor(name, processorCtor) {
 // NOTE: Authors that register an event listener on the "message" event of this
 // port should call close on either end of the MessageChannel (either in the
 // AudioWorklet or the AudioWorkletGlobalScope side) to allow for resources to be collected.
-parentPort.on('exit', () => {
-  process.stdout.write('closing worklet');
-});
+// parentPort.on('exit', () => {
+//   process.stdout.write('closing worklet');
+// });
 
 parentPort.on('message', event => {
-  console.log(event.cmd + '\n');
-
   switch (event.cmd) {
     case 'node-web-audio-api:worklet:init': {
       const { workletId, processors, promiseId } = event;

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -25,6 +25,7 @@ const kWorkletParams = Symbol.for('node-web-audio-api:worklet-params');
 const kWorkletParamsCache = Symbol.for('node-web-audio-api:worklet-params-cache');
 const kWorkletGetBuffer = Symbol.for('node-web-audio-api:worklet-get-buffer');
 const kWorkletRecycleBuffer = Symbol.for('node-web-audio-api:worklet-recycle-buffer');
+const kWorkletRecycleBuffer1 = Symbol.for('node-web-audio-api:worklet-recycle-buffer-1');
 const kWorkletMarkAsUntransferable = Symbol.for('node-web-audio-api:worklet-mark-as-untransferable');
 // const kWorkletOrderedParamNames = Symbol.for('node-web-audio-api:worklet-ordered-param-names');
 
@@ -68,7 +69,10 @@ class BufferPool {
   }
 
   recycle(buffer) {
-    this.#pool.push(buffer);
+    // make sure we cannot polute our pool
+    if (buffer.length === this.#bufferSize) {
+      this.#pool.push(buffer);
+    }
   }
 }
 
@@ -79,6 +83,7 @@ const pool1 = new BufferPool(1, 64);
 // allow rust to access some methods required when io layout change
 globalThis[kWorkletGetBuffer] = () => pool128.get();
 globalThis[kWorkletRecycleBuffer] = buffer => pool128.recycle(buffer);
+globalThis[kWorkletRecycleBuffer1] = buffer => pool1.recycle(buffer);
 globalThis[kWorkletMarkAsUntransferable] = obj => {
   markAsUntransferable(obj);
   return obj;

--- a/js/AudioWorkletNode.js
+++ b/js/AudioWorkletNode.js
@@ -98,14 +98,16 @@ module.exports = (jsExport, nativeBinding) => {
           throw new DOMException(`Failed to construct 'AudioWorkletNode': Invalid 'outputChannelCount' property from AudioWorkletNodeOptions: 'outputChannelCount' length (${parsedOptions.outputChannelCount.length}) does not equal 'numberOfOutputs' (${parsedOptions.numberOfOutputs})`, 'IndexSizeError');
         }
       } else {
-        // If outputChannelCount does not exists,
         // - If both numberOfInputs and numberOfOutputs are 1, set the initial channel count of the node output to 1 and return.
         //   NOTE: For this case, the output chanel count will change to computedNumberOfChannels dynamically based on the input and the channelCountMode at runtime.
-        // - Otherwise set the channel count of each output of the node to 1 and return.
-
-        // @note - not sure what this means, let's go simple
-        parsedOptions.outputChannelCount = new Uint32Array(parsedOptions.numberOfOutputs);
-        parsedOptions.outputChannelCount.fill(1);
+        if (parsedOptions.numberOfInputs === 1 && parsedOptions.numberOfOutputs === 1) {
+          // rust waits for an empty Vec as the special case value
+          parsedOptions.outputChannelCount = new Uint32Array(0);
+        } else {
+          // - Otherwise set the channel count of each output of the node to 1 and return.
+          parsedOptions.outputChannelCount = new Uint32Array(parsedOptions.numberOfOutputs);
+          parsedOptions.outputChannelCount.fill(1);
+        }
       }
 
       // @todo

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -455,7 +455,7 @@ pub(crate) fn run_audio_worklet_global_scope(ctx: CallContext) -> Result<JsUndef
                 let mut processors = ctx.get::<JsObject>(1)?;
                 // recycle all processor buffers
                 let processor = processors.get_named_property::<JsObject>(&id.to_string())?;
-                let _ = recycle_processor(ctx.env, processor)?;
+                recycle_processor(ctx.env, processor)?;
 
                 processors.delete_named_property(&id.to_string())?;
             }

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -184,7 +184,7 @@ fn rebuild_io_layout(
         let old_channels = js_io.get_element::<JsObject>(i as u32).unwrap();
         // recycle old channels
         for j in 0..old_channels.get_array_length()? {
-            let channel = old_channels.get_element::<JsTypedArray>(j as u32).unwrap();
+            let channel = old_channels.get_element::<JsTypedArray>(j).unwrap();
             let _ = recycle_buffer.call1::<JsTypedArray, JsUndefined>(channel);
         }
         // populate channels


### PR DESCRIPTION
Built on top of #131 

Use a thread pool in worklets to minimize allocations and ensure that input and output cannot be transfered to main thread

```
  RESULTS:
  - # pass: 7299
  - # fail: 527
  - # type error issues: 3
> wpt duration: 2:50.251 (m:ss.mmm)
```