### PR TITLE
Fix missing type export declaration in `"exports"` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Node.js bindings for web-audio-api-rs using napi-rs",
   "exports": {
     "import": "./index.mjs",
-    "require": "./index.cjs"
+    "require": "./index.cjs",
+    "types": "./index.d.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
An error appears when importing this package in [a TypeScript project](/eco-repositories/eco-monorepo). Basically, it says that the types are there, but `"exports"` field doesn't mention them, so they can't be imported:

```
Could not find a declaration file for module 'node-web-audio-api'. 'path/to/node_modules/node-web-audio-api/index.mjs' implicitly has an 'any' type.
  There are types at 'path/to/node_modules/node-web-audio-api/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'node-web-audio-api' library may need to update its package.json or typings.ts(7016)
```

<img width="1049" alt="372068580-588cd423-7da7-4b1e-af3b-94843b8b23ac" src="https://github.com/user-attachments/assets/989c7fe3-2da4-4b25-8730-675f1f389e05">

This PR fixes that.
