### PR TITLE
Use older glibc for linux builds

### DIFF
--- a/.scripts/BUILD_NOTES.md
+++ b/.scripts/BUILD_NOTES.md
@@ -33,10 +33,19 @@ Profile (which tools and data to install)? (minimal/default/complete) [default]
 sudo apt-get install -y libjack-jackd2-dev libasound2-dev
 ```
 
-
 # Docker image
 
 ```
 cd ./.scripts/docker_x86_64-unknown-linux-gnu/
 docker build -t bbmmaa/build-x86_64 .
 ```
+
+## GLIBC version
+
+The Docker image tag is essential to set the minimum GLIBC version:
+
+-   Debian 12 (Bookworm) -> GLIBC 2.36
+-   Debian 11 (Bullseye) -> GLIBC 2.31
+-   Debian 10 (Buster) -> GLIBC 2.28
+
+Some deployment platforms like Vercel and AWS still use old versions of GLIBC, so we need to build the Docker image with an older GLIBC version.

--- a/.scripts/build-linux-gnu-docker.mjs
+++ b/.scripts/build-linux-gnu-docker.mjs
@@ -6,7 +6,7 @@ console.log(`> executing docker command in dir ${cwd}`);
 // the source code directory is shared with the docker image,
 // so every thing is always up to date
 
-// @todo - rebuild docket image
+// @todo - rebuild docker image
 // cd ./.scripts/docker_x86_64-unknown-linux-gnu/
 // docker build -t bbmmaa/build-x86_64 .
 
@@ -19,5 +19,7 @@ execSync(`docker run --rm \
   bash -c "
     yarn build:jack --target x86_64-unknown-linux-gnu && \
     x86_64-linux-gnu-strip *.linux-x64-gnu.node && \
-    ls -al /sources"
+    ls -al /sources && \
+    echo 'GLIBC version requirements:' && \
+    objdump -p *.linux-x64-gnu.node | grep GLIBC"
 `, { stdio: 'inherit' });

--- a/.scripts/docker_x86_64-unknown-linux-gnu/Dockerfile
+++ b/.scripts/docker_x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20
+FROM node:20-buster
+# buster means minimum GLIBC version is 2.28 (2019)
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
Fix #22 
Fix #22 

These are the new GLIBC version requirements for the binary:

```
GLIBC version requirements:
    0x09691a75 0x00 20 GLIBC_2.2.5
    0x09691a75 0x00 14 GLIBC_2.2.5
    0x0d696913 0x00 13 GLIBC_2.3
    0x06969192 0x00 10 GLIBC_2.12
    0x09691a75 0x00 07 GLIBC_2.2.5
    0x06969187 0x00 05 GLIBC_2.27
    0x09691a75 0x00 04 GLIBC_2.2.5
    0x06969194 0x00 21 GLIBC_2.14
    0x06969188 0x00 19 GLIBC_2.28
    0x09691974 0x00 17 GLIBC_2.3.4
    0x06969185 0x00 15 GLIBC_2.25
    0x0d696913 0x00 12 GLIBC_2.3
    0x06969198 0x00 11 GLIBC_2.18
    0x09691a75 0x00 02 GLIBC_2.2.5
```

As you can see now the minimum one is GLIBC_2.3.4, which is much lower than GLIBC_2.35

I opened this PR because i could not deploy on Vercel, which still uses GLIBC_2.34 I think