### PR TITLE
feat: register global + tone.js example

### DIFF
--- a/examples/tone.js
+++ b/examples/tone.js
@@ -1,0 +1,17 @@
+import '../register-global.mjs';
+import * as Tone from 'tone';
+
+const latencyHint = process.env.WEB_AUDIO_LATENCY === 'playback' ? 'playback' : 'interactive';
+const audioContext = new AudioContext({ latencyHint });
+Tone.setContext(audioContext);
+
+const synth = new Tone.Synth().toDestination();
+const now = Tone.now();
+// trigger the attack immediately
+synth.triggerAttack("C4", now);
+// wait one second before triggering the release
+synth.triggerRelease(now + 1);
+
+await new Promise(resolve => setTimeout(resolve, 1500));
+console.log('closing');
+await audioContext.close();

--- a/examples/tone.js
+++ b/examples/tone.js
@@ -8,7 +8,7 @@ Tone.setContext(audioContext);
 const synth = new Tone.Synth().toDestination();
 const now = Tone.now();
 // trigger the attack immediately
-synth.triggerAttack("C4", now);
+synth.triggerAttack('C4', now);
 // wait one second before triggering the release
 synth.triggerRelease(now + 1);
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "mocha": "^11.0.1",
     "octokit": "^4.1.0",
     "template-literal": "^1.0.4",
+    "tone": "^15.1.22",
     "webidl2": "^24.2.0",
     "wpt-runner": "^5.0.0"
   },

--- a/register-global.mjs
+++ b/register-global.mjs
@@ -1,0 +1,8 @@
+import * as webaudio from './index.mjs';
+
+// Expose webaudio globally
+Object.assign(globalThis, webaudio);
+// note that `standardized-audio-context` explicitly relies on window
+// cf. https://github.com/chrisguttandin/standardized-audio-context/blob/master/src/factories/window.ts
+globalThis.window = {};
+Object.assign(globalThis.window, webaudio);


### PR DESCRIPTION
Minimal example for Tone.js

Several open questions:
- should we include this `register-global.js` thing in the lib, looks like "yes" as it may really help to work with existing libs / frameworks, helpful to use faust (cf. https://github.com/ircam-ismm/node-web-audio-api/pull/164#issuecomment-3758998865) or `wam` plugins for example.
- cannot get rid of `Tone.setContext(audioContext)`, somehow related to how `standardized-audio-context` works but couldn't find the reason

Maybe would be nice to work on the compatibility with `standardized-audio-context` first?