### PR TITLE
Some AudioWorklet refactoring and improvements

### DIFF
--- a/.scripts/wpt-harness.js
+++ b/.scripts/wpt-harness.js
@@ -39,6 +39,7 @@ const ignoreCases = [
   'the-audio-api/the-iirfilternode-interface/iir-filter-silent-block-crash.html',
   'the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource-mediaStreamAudioDestination-stream-crash.html',
   'the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource_closed_context-crash.html',
+  'the-audio-api/the-audioworklet-interface/process-parameters.https.html',
 ]
 
 // -------------------------------------------------------

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -264,7 +264,7 @@ parentPort.on('message', async event => {
           // super may have been called but instance did throw, we can reset super
           pendingProcessor.super = null;
           pendingProcessor.instance = new AudioWorkletProcessor(options);
-          pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:ctor-error', err]);
+          pendingProcessor.instance[kWorkletMarkNonCallableProcess]('node-web-audio-api:worklet:ctor-error', err);
         }
       }
 
@@ -277,7 +277,7 @@ parentPort.on('message', async event => {
       if (!isMock) {
         if (!('process' in pendingProcessor.instance)) {
           const err = new TypeError(`Invalid AudioWorkletNode "${pendingProcessor.instance.constructor.name}": Invalid "process" method`);
-          pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:process-invalid', err]);
+          pendingProcessor.instance[kWorkletMarkNonCallableProcess]('node-web-audio-api:worklet:process-invalid', err);
         }
       }
 

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -272,9 +272,10 @@ parentPort.on('message', async event => {
       // If execution of process fail for any reason, it will be catched in
       // AudioWorkletProcessor::[kWorkletUnpackProcess]
       // cf. wpt/webaudio/the-audio-api/the-audioworklet-interface/process-getter.https.html
+      // Do not use `hasOwnProperty` because we cannot assume that we know
+      // the prototype chain.
       if (!isMock) {
-        if (!Object.prototype.hasOwnProperty.call(ctor.prototype, 'process')
-          && !Object.prototype.hasOwnProperty.call(pendingProcessor.instance, 'process')) {
+        if (!('process' in pendingProcessor.instance)) {
           const err = new TypeError(`Invalid AudioWorkletNode "${pendingProcessor.instance.constructor.name}": Invalid "process" method`);
           pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:process-invalid', err]);
         }

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -251,17 +251,18 @@ parentPort.on('message', async event => {
       try {
         pendingProcessor.instance = new ctor(options);
       } catch (err) {
-        // if the given processor constructor failed, we create a dummy processor
+        errored = true;
+
+        // If the given processor constructor failed, we create a dummy processor
         // that we mark immediately as non-callable. This prevents situations where
         // the NapiAudioWorkletProcessor, which already exists at this point, hangs
         // forever waiting for its JS counterpart
         // @todo - This design could be improved in the future by flagging somehow
         // the Rust processor to avoid the cross thread communication
-        errored = true;
-
         if (!pendingProcessor.instance) {
           isMock = true;
-
+          // super may have been called but instance did throw, we can reset super
+          pendingProcessor.super = null;
           pendingProcessor.instance = new AudioWorkletProcessor(options);
           pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:ctor-error', err]);
         }
@@ -284,6 +285,7 @@ parentPort.on('message', async event => {
 
       pendingProcessor.constructionData = null;
       pendingProcessor.instance = null;
+      pendingProcessor.super = null;
       // notify main thread that instantiation has finished somehow
       if (errored) {
         parentPort.postMessage({ cmd: 'node-web-audio-api:worklet:ctor-error', id });

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -268,19 +268,19 @@ parentPort.on('message', async event => {
         }
       }
 
-      // check that process method exists either on instance or on prototype
-      // cf. wpt/webaudio/the-audio-api/the-audioworklet-interface/process-getter.https.html
+      // Check that process method exists either on instance or on prototype.
       // If execution of process fail for any reason, it will be catched in
       // AudioWorkletProcessor::[kWorkletUnpackProcess]
+      // cf. wpt/webaudio/the-audio-api/the-audioworklet-interface/process-getter.https.html
       if (!isMock) {
-        if (!ctor.prototype.hasOwnProperty('process') && !pendingProcessor.instance.hasOwnProperty('process')) {
+        if (!Object.prototype.hasOwnProperty.call(ctor.prototype, 'process')
+          && !Object.prototype.hasOwnProperty.call(pendingProcessor.instance, 'process')) {
           const err = new TypeError(`Invalid AudioWorkletNode "${pendingProcessor.instance.constructor.name}": Invalid "process" method`);
           pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:process-invalid', err]);
         }
       }
 
-      // store in global so that Rust can match the JS processor
-      // with its corresponding NapiAudioWorkletProcessor
+      // Store in global to match the JS processor with its corresponding NapiAudioWorkletProcessor
       processors[`${id}`] = pendingProcessor.instance;
 
       pendingProcessor.constructionData = null;

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -10,24 +10,18 @@ import { AudioWorkletProcessor } from './AudioWorkletProcessor.js';
 import { isIterable } from './lib/is-iterable.js';
 import { isConstructor } from './lib/is-constructor.js';
 import {
-  kWorkletCallableProcess,
   kWorkletMarkNonCallableProcess,
-  kWorkletInputs,
-  kWorkletOutputs,
-  kWorkletParams,
-  kWorkletParamsCache,
   kWorkletGetBuffer,
   kWorkletGetBuffer1,
   kWorkletRecycleBuffer,
   kWorkletRecycleBuffer1,
   kWorkletMarkAsUntransferable,
-  kWorkletUnpackProcess,
 } from './lib/audio-worklet/symbols.js';
 import {
   pendingProcessorConstructionData,
-} from './lib/audio-worklet/pending-processor-construction-data.js'
+} from './lib/audio-worklet/pending-processor-construction-data.js';
 import {
-  BufferPool
+  BufferPool,
 } from './lib/audio-worklet/BufferPool.js';
 
 import nativeBinding from '../load-native.js';

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -246,6 +246,7 @@ parentPort.on('message', async event => {
       };
 
       let errored = false;
+      let isMock = false;
 
       try {
         pendingProcessor.instance = new ctor(options);
@@ -259,12 +260,16 @@ parentPort.on('message', async event => {
         errored = true;
 
         if (!pendingProcessor.instance) {
+          isMock = true;
+
           pendingProcessor.instance = new AudioWorkletProcessor(options);
           pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:ctor-error', err]);
         }
       }
 
-      if (!(typeof pendingProcessor.instance.process === 'function')) {
+      // if instance is a mock, we know it as no `process` method and it has
+      // already been marked as non callable, no need to report it again
+      if (!isMock && typeof pendingProcessor.instance.process !== 'function') {
         const err = new TypeError(`Invalid AudioWorkletNode "${pendingProcessor.instance.constructor.name}": no process method found`);
         pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:process-invalid', err]);
       }

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -18,8 +18,8 @@ import {
   kWorkletMarkAsUntransferable,
 } from './lib/audio-worklet/symbols.js';
 import {
-  pendingProcessorConstructionData,
-} from './lib/audio-worklet/pending-processor-construction-data.js';
+  pendingProcessor,
+} from './lib/audio-worklet/pending-processor.js';
 import {
   BufferPool,
 } from './lib/audio-worklet/BufferPool.js';
@@ -236,19 +236,20 @@ parentPort.on('message', async event => {
       const ctor = nameProcessorCtorMap.get(name);
 
       // entities of interest for the AudioWorkletProcess base class
-      pendingProcessorConstructionData.inner = {
+      pendingProcessor.constructionData = {
         messagePort,
         errorPort,
         numberOfInputs: options.numberOfInputs,
         numberOfOutputs: options.numberOfOutputs,
         parameterDescriptors: ctor.parameterDescriptors,
+        errored: null,
       };
 
-      let instance;
+      // let instance;
       let errored = false;
 
       try {
-        instance = new ctor(options);
+        pendingProcessor.instance = new ctor(options);
       } catch (err) {
         // if the given processor constructor failed, we create a dummy processor
         // that we mark immediately as non-callable. This prevents situations where
@@ -257,14 +258,24 @@ parentPort.on('message', async event => {
         // @todo - This design could be improved in the future by flagging somehow
         // the Rust processor to avoid the cross thread communication
         errored = true;
-        instance = new AudioWorkletProcessor(options);
-        instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:ctor-error', err]);
+
+        if (!pendingProcessor.instance) {
+          pendingProcessor.instance = new AudioWorkletProcessor(options);
+          pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:ctor-error', err]);
+        }
       }
 
-      pendingProcessorConstructionData.inner = null;
+      if (!(typeof pendingProcessor.instance.process === 'function')) {
+        const err = new TypeError(`Invalid AudioWorkletNode "${pendingProcessor.instance.constructor.name}": no process method found`);
+        pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:process-invalid', err]);
+      }
+
       // store in global so that Rust can match the JS processor
       // with its corresponding NapiAudioWorkletProcessor
-      processors[`${id}`] = instance;
+      processors[`${id}`] = pendingProcessor.instance;
+
+      pendingProcessor.constructionData = null;
+      pendingProcessor.instance = null;
       // notify main thread that instantiation has finished somehow
       if (errored) {
         parentPort.postMessage({ cmd: 'node-web-audio-api:worklet:ctor-error', id });

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -267,11 +267,15 @@ parentPort.on('message', async event => {
         }
       }
 
-      // if instance is a mock, we know it as no `process` method and it has
-      // already been marked as non callable, no need to report it again
-      if (!isMock && typeof pendingProcessor.instance.process !== 'function') {
-        const err = new TypeError(`Invalid AudioWorkletNode "${pendingProcessor.instance.constructor.name}": no process method found`);
-        pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:process-invalid', err]);
+      // check that process method exists either on instance or on prototype
+      // cf. wpt/webaudio/the-audio-api/the-audioworklet-interface/process-getter.https.html
+      // If execution of process fail for any reason, it will be catched in
+      // AudioWorkletProcessor::[kWorkletUnpackProcess]
+      if (!isMock) {
+        if (!ctor.prototype.hasOwnProperty('process') && !pendingProcessor.instance.hasOwnProperty('process')) {
+          const err = new TypeError(`Invalid AudioWorkletNode "${pendingProcessor.instance.constructor.name}": Invalid "process" method`);
+          pendingProcessor.instance[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:process-invalid', err]);
+        }
       }
 
       // store in global so that Rust can match the JS processor

--- a/js/AudioWorkletGlobalScope.js
+++ b/js/AudioWorkletGlobalScope.js
@@ -245,7 +245,6 @@ parentPort.on('message', async event => {
         errored: null,
       };
 
-      // let instance;
       let errored = false;
 
       try {

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -83,16 +83,14 @@ export class AudioWorkletProcessor {
   // - unpack arguments from napi-rs `apply`
   // - cast return value to boolean
   // - catch and cleanly return error so that rust can properly handle it
-  //
-  // This method is called only if a "real" process method has been found
+  // This method is called only if a "real" process attribute has been found at construction
+  // However if this is the first call we don't know yet if process is callable
   [kWorkletUnpackProcess]([inputs, outputs, parameters]) {
-    // output must be cleaned up and filled with zeros
-    // cf. the-audioworklet-interface/audioworkletprocessor-unconnected-outputs.https.window.html
-    outputs.forEach(output => output.forEach(channel => channel.fill(0)));
-
     try {
       return !!this.process(inputs, outputs, parameters);
     } catch (err) {
+      // no need to return the error to rust and have another roundtrip
+      // we can just mark the process as non callable here and return false
       let returnedError;
       // make sure Rust receives a "real" error instance, i.e. support `throw "my message";`
       if (!Error.isError(err)) {

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -89,11 +89,12 @@ export class AudioWorkletProcessor {
     try {
       return !!this.process(inputs, outputs, parameters);
     } catch (err) {
-      // no need to return the error to rust and have another roundtrip
       // we can just mark the process as non callable here and return false
+      // (no need to return the error to rust and have another rust / js roundtrip)
       let error;
-      // make sure Rust receives a "real" error instance, i.e. support `throw "my message";`
-      if (!Error.isError(err)) {
+      // make sure we propagate an error instance, i.e. support `throw "my message";`
+      // @note that `Error.isError` is not available in Node v22
+      if (!(err instanceof Error)) {
         error = new Error(err);
       } else {
         error = err;

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -22,7 +22,9 @@ export class AudioWorkletProcessor {
   #errorPort = null;
 
   constructor() {
-    if (pendingProcessor.instance !== null) {
+    // check that this constructor has never been called for this processor instantiation
+    // cf. wpt/webaudio/the-audio-api/the-audioworklet-interface/processor-construction-port.https.html
+    if (pendingProcessor.super !== null) {
       this[kWorkletCallableProcess] = false;
       throw new TypeError('Cannot construct "AudioWorkletProcessor": Invalid pending construction data');;
     }
@@ -38,7 +40,7 @@ export class AudioWorkletProcessor {
     this.#messagePort = messagePort;
     this.#errorPort = errorPort;
 
-    pendingProcessor.instance = this;
+    pendingProcessor.super = this;
 
     // Mark [[callable process]] as true, set to false in render quantum
     // either if "process" does not exists or if it throws an error

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -67,7 +67,7 @@ export class AudioWorkletProcessor {
         ];
       }
     } catch (err) {
-      this[kWorkletMarkNonCallableProcess](['node-web-audio-api:worklet:ctor-error', err]);
+      this[kWorkletMarkNonCallableProcess]('node-web-audio-api:worklet:ctor-error', err);
     }
   }
 
@@ -82,7 +82,7 @@ export class AudioWorkletProcessor {
   // Wrapper around the "real" process method that allows to
   // - unpack arguments from napi-rs `apply`
   // - cast return value to boolean
-  // - catch and cleanly return error so that rust can properly handle it
+  // - catch and propagate error while keeping the rust side clean
   // This method is called only if a "real" process attribute has been found at construction
   // However if this is the first call we don't know yet if process is callable
   [kWorkletUnpackProcess]([inputs, outputs, parameters]) {
@@ -91,19 +91,21 @@ export class AudioWorkletProcessor {
     } catch (err) {
       // no need to return the error to rust and have another roundtrip
       // we can just mark the process as non callable here and return false
-      let returnedError;
+      let error;
       // make sure Rust receives a "real" error instance, i.e. support `throw "my message";`
       if (!Error.isError(err)) {
-        returnedError = new Error(err);
+        error = new Error(err);
       } else {
-        returnedError = err;
+        error = err;
       }
 
-      return returnedError;
+      this[kWorkletMarkNonCallableProcess]('node-web-audio-api:worklet:process-error', error);
+
+      return false;
     }
   }
 
-  [kWorkletMarkNonCallableProcess]([cmd, err]) {
+  [kWorkletMarkNonCallableProcess](cmd, err) {
     this[kWorkletCallableProcess] = false;
     this.#errorPort.postMessage({ cmd, err });
   }

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -91,12 +91,15 @@ export class AudioWorkletProcessor {
     try {
       return !!this.process(inputs, outputs, parameters);
     } catch (err) {
+      let returnedError;
       // make sure Rust receives a "real" error instance, i.e. support `throw "my message";`
       if (!Error.isError(err)) {
-        err = new Error(err);
+        returnedError = new Error(err);
+      } else {
+        returnedError = err;
       }
 
-      return err;
+      return returnedError;
     }
   }
 

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -7,14 +7,11 @@ import {
   kWorkletParamsCache,
   kWorkletGetBuffer,
   kWorkletGetBuffer1,
-  kWorkletRecycleBuffer,
-  kWorkletRecycleBuffer1,
-  kWorkletMarkAsUntransferable,
   kWorkletUnpackProcess,
 } from './lib/audio-worklet/symbols.js';
 import {
   pendingProcessorConstructionData,
-} from './lib/audio-worklet/pending-processor-construction-data.js'
+} from './lib/audio-worklet/pending-processor-construction-data.js';
 
 export class AudioWorkletProcessor {
   static get parameterDescriptors() {

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -26,7 +26,7 @@ export class AudioWorkletProcessor {
     // cf. wpt/webaudio/the-audio-api/the-audioworklet-interface/processor-construction-port.https.html
     if (pendingProcessor.super !== null) {
       this[kWorkletCallableProcess] = false;
-      throw new TypeError('Cannot construct "AudioWorkletProcessor": Invalid pending construction data');;
+      throw new TypeError(`Cannot construct "${this.constructor.name}": Invalid pending construction data`);
     }
 
     const {

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -43,8 +43,8 @@ export class AudioWorkletProcessor {
     // not for the reason explained
     try {
       // Populate with dummy values which will be replaced in first render call
-      this[kWorkletInputs] = new Array(numberOfInputs).fill([]);
-      this[kWorkletOutputs] = new Array(numberOfOutputs).fill([]);
+      this[kWorkletInputs] = Object.freeze(new Array(numberOfInputs).fill(Object.freeze([])));
+      this[kWorkletOutputs] = Object.freeze( new Array(numberOfOutputs).fill(Object.freeze([])));
       // Object to be reused as `process` parameters argument
       this[kWorkletParams] = {};
       // Cache of 2 Float32Array (of length 128 and 1) for each param, to be reused on
@@ -77,11 +77,9 @@ export class AudioWorkletProcessor {
   //
   // This method is called only if a "real" process method has been found
   [kWorkletUnpackProcess]([inputs, outputs, parameters]) {
-    // output must be filled with zero
+    // output must be cleaned up and filled with zeros
     // cf. the-audioworklet-interface/audioworkletprocessor-unconnected-outputs.https.window.html
-    outputs.forEach(output => {
-      output.forEach(channel => channel.fill(0));
-    });
+    outputs.forEach(output => output.forEach(channel => channel.fill(0)));
 
     try {
       return !!this.process(inputs, outputs, parameters);

--- a/js/AudioWorkletProcessor.js
+++ b/js/AudioWorkletProcessor.js
@@ -10,8 +10,8 @@ import {
   kWorkletUnpackProcess,
 } from './lib/audio-worklet/symbols.js';
 import {
-  pendingProcessorConstructionData,
-} from './lib/audio-worklet/pending-processor-construction-data.js';
+  pendingProcessor,
+} from './lib/audio-worklet/pending-processor.js';
 
 export class AudioWorkletProcessor {
   static get parameterDescriptors() {
@@ -22,16 +22,23 @@ export class AudioWorkletProcessor {
   #errorPort = null;
 
   constructor() {
+    if (pendingProcessor.instance !== null) {
+      this[kWorkletCallableProcess] = false;
+      throw new TypeError('Cannot construct "AudioWorkletProcessor": Invalid pending construction data');;
+    }
+
     const {
       messagePort,
       errorPort,
       numberOfInputs,
       numberOfOutputs,
       parameterDescriptors,
-    } = pendingProcessorConstructionData.inner;
+    } = pendingProcessor.constructionData;
 
     this.#messagePort = messagePort;
     this.#errorPort = errorPort;
+
+    pendingProcessor.instance = this;
 
     // Mark [[callable process]] as true, set to false in render quantum
     // either if "process" does not exists or if it throws an error
@@ -84,6 +91,11 @@ export class AudioWorkletProcessor {
     try {
       return !!this.process(inputs, outputs, parameters);
     } catch (err) {
+      // make sure Rust receives a "real" error instance, i.e. support `throw "my message";`
+      if (!Error.isError(err)) {
+        err = new Error(err);
+      }
+
       return err;
     }
   }

--- a/js/BaseAudioContext.js
+++ b/js/BaseAudioContext.js
@@ -514,8 +514,8 @@ Object.defineProperties(BaseAudioContext.prototype, {
   currentTime: kEnumerableProperty,
   renderQuantumSize: kEnumerableProperty,
   state: kEnumerableProperty,
-  onstatechange: kEnumerableProperty,
   decodeAudioData: kEnumerableProperty,
   createBuffer: kEnumerableProperty,
   createPeriodicWave: kEnumerableProperty,
+  onstatechange: kEnumerableProperty,
 });

--- a/js/lib/audio-worklet/BufferPool.js
+++ b/js/lib/audio-worklet/BufferPool.js
@@ -39,9 +39,11 @@ export class BufferPool {
   }
 
   recycle(buffer) {
-    // make sure we can't pollute the pool
-    if (buffer.length === this.#bufferSize) {
-      this.#pool.push(buffer);
+    // make sure we don't pollute the pool
+    if (buffer.length !== this.#bufferSize) {
+      throw new Error(`Attempt to recycle a buffer of length ${buffer.length} in a pool of buffers of length ${this.#bufferSize}`);
     }
+
+    this.#pool.push(buffer);
   }
 }

--- a/js/lib/audio-worklet/pending-processor-construction-data.js
+++ b/js/lib/audio-worklet/pending-processor-construction-data.js
@@ -1,1 +1,0 @@
-export const pendingProcessorConstructionData = { inner: null };

--- a/js/lib/audio-worklet/pending-processor.js
+++ b/js/lib/audio-worklet/pending-processor.js
@@ -1,0 +1,4 @@
+export const pendingProcessor = {
+  constructionData: null,
+  instance: null,
+};

--- a/js/lib/audio-worklet/pending-processor.js
+++ b/js/lib/audio-worklet/pending-processor.js
@@ -1,4 +1,5 @@
 export const pendingProcessor = {
   constructionData: null,
-  instance: null,
+  instance: null, // mark derived class constructor as been successfully called
+  super: null, // mark AudioWorkletProcessor constructor as been called
 };

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -314,125 +314,104 @@ fn process_audio_worklet(
         return Ok(());
     }
 
-    // The `process` method is not executed directly because napi-rs `apply`
+    let render_quantum_size = global.get_named_property::<u32>("renderQuantumSize")? as usize;
+    // The `process` method is executed indirectly because napi-rs `apply`
     // implementation retrieve the arguments as an array in the first argument, Then
     // we need to unpack them first (cf. `AudioWorkletProcessor[kWorkletUnpackProcess]`)
+    let k_worklet_unpack_process = env.symbol_for("node-web-audio-api:worklet-unpack-process")?;
+
+    // The `kWorkletUnpackProcess` wrapper function coerce value returned from `process`
+    // to bool, therefore if we get anything else, i.e. `Unknown`, an error occurred.
+    let unpack_process_function = processor
+        .get_property::<JsSymbol, Function<(Array, Array, Object), Either<bool, Unknown>>>(
+            k_worklet_unpack_process,
+        )?;
+
+    let k_worklet_inputs = env.symbol_for("node-web-audio-api:worklet-inputs")?;
+    let mut js_inputs = processor.get_property::<JsSymbol, Array>(k_worklet_inputs)?;
+
+    let k_worklet_outputs = env.symbol_for("node-web-audio-api:worklet-outputs")?;
+    let mut js_outputs = processor.get_property::<JsSymbol, Array>(k_worklet_outputs)?;
+
+    // <param_name, buffer>
+    let k_worklet_params = env.symbol_for("node-web-audio-api:worklet-params")?;
+    let mut js_params = processor.get_property::<JsSymbol, Object>(k_worklet_params)?;
+    // <param_name, [Float32Array(128), Float32Array(1)]>
+    let k_worklet_params_cache = env.symbol_for("node-web-audio-api:worklet-params-cache")?;
+    let js_params_cache = processor.get_property::<JsSymbol, Object>(k_worklet_params_cache)?;
+
+    // Check input and output channel layout, and rebuild JS object if something changed
+    if !is_same_io_layout(&js_inputs, inputs) {
+        let new_js_inputs = rebuild_io_layout(env, js_inputs, inputs)?;
+        processor.set_property(k_worklet_inputs, new_js_inputs)?;
+        js_inputs = processor.get_property::<JsSymbol, Array>(k_worklet_inputs)?;
+    }
+
+    if !is_same_io_layout(&js_outputs, outputs) {
+        let new_js_outputs = rebuild_io_layout(env, js_outputs, outputs)?;
+        processor.set_property(k_worklet_outputs, new_js_outputs)?;
+        js_outputs = processor.get_property::<JsSymbol, Array>(k_worklet_outputs)?;
+    }
+
+    // Copy inputs into JS inputs buffers
+    for (input_number, input) in inputs.iter().enumerate() {
+        let js_input = js_inputs.get::<Array>(input_number as u32)?.unwrap();
+
+        for (channel_number, channel) in input.iter().enumerate() {
+            let mut js_channel = js_input
+                .get::<Float32Array>(channel_number as u32)?
+                .unwrap();
+            let js_channel: &mut [f32] = unsafe { js_channel.as_mut() };
+            js_channel.copy_from_slice(channel);
+        }
+    }
+
+    // Copy params values into JS params buffers
     //
-    // Note that we use `get_named_property` rather than `has_named_property` so that
-    // we check that `process` is a function as well.
-    let process_method_result =
-        processor.get_named_property::<Function<Unknown, Unknown>>("process");
+    // @todo(perf) - We could rely on the fact that ParameterDescriptors
+    // are ordered maps to avoid sending param names in `param_values`
+    for (name, data) in param_values.iter() {
+        let float32_arr_cache = js_params_cache.get_named_property::<Array>(name)?;
+        // retrieve right Float32Array according to actual param size, i.e. 128 or 1
+        let cache_index = if data.len() == 1 { 1 } else { 0 };
+        let mut param_values = float32_arr_cache.get::<Float32Array>(cache_index)?.unwrap();
+        // copy data into underlying ArrayBuffer
+        let buffer: &mut [f32] = unsafe { param_values.as_mut() };
+        buffer.copy_from_slice(data);
+        // replace current values with new Float32Array
+        js_params.set_named_property(name, param_values)?;
+    }
 
-    let abrupt_completion = match process_method_result {
-        Ok(_process_method) => {
-            let render_quantum_size =
-                global.get_named_property::<u32>("renderQuantumSize")? as usize;
+    let js_result = unpack_process_function.apply(processor, (js_inputs, js_outputs, js_params))?;
 
-            let k_worklet_unpack_process =
-                env.symbol_for("node-web-audio-api:worklet-unpack-process")?;
+    let abrupt_completion = match js_result {
+        Either::A(tail_time) => {
+            // copy JS output buffers back into outputs
+            for (output_number, output) in outputs.iter().enumerate() {
+                let js_output = js_outputs.get_element::<Array>(output_number as u32)?;
 
-            // The `kWorkletUnpackProcess` wrapper function coerce value returned from `process`
-            // to bool, therefore if we get anything else, i.e. `Unknown`, an error occurred.
-            let unpack_process_function = processor
-                .get_property::<JsSymbol, Function<(Array, Array, Object), Either<bool, Unknown>>>(
-                    k_worklet_unpack_process,
-                )?;
-
-            let k_worklet_inputs = env.symbol_for("node-web-audio-api:worklet-inputs")?;
-            let mut js_inputs = processor.get_property::<JsSymbol, Array>(k_worklet_inputs)?;
-
-            let k_worklet_outputs = env.symbol_for("node-web-audio-api:worklet-outputs")?;
-            let mut js_outputs = processor.get_property::<JsSymbol, Array>(k_worklet_outputs)?;
-
-            // <param_name, buffer>
-            let k_worklet_params = env.symbol_for("node-web-audio-api:worklet-params")?;
-            let mut js_params = processor.get_property::<JsSymbol, Object>(k_worklet_params)?;
-            // <param_name, [Float32Array(128), Float32Array(1)]>
-            let k_worklet_params_cache =
-                env.symbol_for("node-web-audio-api:worklet-params-cache")?;
-            let js_params_cache =
-                processor.get_property::<JsSymbol, Object>(k_worklet_params_cache)?;
-
-            // Check input and output channel layout, and rebuild JS object if something changed
-            if !is_same_io_layout(&js_inputs, inputs) {
-                let new_js_inputs = rebuild_io_layout(env, js_inputs, inputs)?;
-                processor.set_property(k_worklet_inputs, new_js_inputs)?;
-                js_inputs = processor.get_property::<JsSymbol, Array>(k_worklet_inputs)?;
-            }
-
-            if !is_same_io_layout(&js_outputs, outputs) {
-                let new_js_outputs = rebuild_io_layout(env, js_outputs, outputs)?;
-                processor.set_property(k_worklet_outputs, new_js_outputs)?;
-                js_outputs = processor.get_property::<JsSymbol, Array>(k_worklet_outputs)?;
-            }
-
-            // Copy inputs into JS inputs buffers
-            for (input_number, input) in inputs.iter().enumerate() {
-                let js_input = js_inputs.get::<Array>(input_number as u32)?.unwrap();
-
-                for (channel_number, channel) in input.iter().enumerate() {
-                    let mut js_channel = js_input
+                for (channel_number, channel) in output.iter().enumerate() {
+                    let js_channel = js_output
                         .get::<Float32Array>(channel_number as u32)?
                         .unwrap();
-                    let js_channel: &mut [f32] = unsafe { js_channel.as_mut() };
-                    js_channel.copy_from_slice(channel);
-                }
-            }
 
-            // Copy params values into JS params buffers
-            //
-            // @todo(perf) - We could rely on the fact that ParameterDescriptors
-            // are ordered maps to avoid sending param names in `param_values`
-            for (name, data) in param_values.iter() {
-                let float32_arr_cache = js_params_cache.get_named_property::<Array>(name)?;
-                // retrieve right Float32Array according to actual param size, i.e. 128 or 1
-                let cache_index = if data.len() == 1 { 1 } else { 0 };
-                let mut param_values = float32_arr_cache.get::<Float32Array>(cache_index)?.unwrap();
-                // copy data into underlying ArrayBuffer
-                let buffer: &mut [f32] = unsafe { param_values.as_mut() };
-                buffer.copy_from_slice(data);
-                // replace current values with new Float32Array
-                js_params.set_named_property(name, param_values)?;
-            }
+                    let src = js_channel.as_ptr();
+                    let dst = channel.as_ptr() as *mut f32;
 
-            let js_result =
-                unpack_process_function.apply(processor, (js_inputs, js_outputs, js_params))?;
-
-            match js_result {
-                Either::A(tail_time) => {
-                    // copy JS output buffers back into outputs
-                    for (output_number, output) in outputs.iter().enumerate() {
-                        let js_output = js_outputs.get_element::<Array>(output_number as u32)?;
-
-                        for (channel_number, channel) in output.iter().enumerate() {
-                            let js_channel = js_output
-                                .get::<Float32Array>(channel_number as u32)?
-                                .unwrap();
-
-                            let src = js_channel.as_ptr();
-                            let dst = channel.as_ptr() as *mut f32;
-
-                            unsafe {
-                                std::ptr::copy_nonoverlapping(src, dst, render_quantum_size);
-                            }
-                        }
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(src, dst, render_quantum_size);
                     }
-
-                    let _ = tail_time_sender.send(tail_time); // allowed to fail
-
-                    None
                 }
-                // error thrown in process
-                Either::B(err) => Some(WorkletAbruptCompletionResult {
-                    cmd: "node-web-audio-api:worklet:process-error".to_string(),
-                    err: err.into(),
-                }),
             }
+
+            let _ = tail_time_sender.send(tail_time); // allowed to fail
+
+            None
         }
-        // no process method found
-        Err(err) => Some(WorkletAbruptCompletionResult {
-            cmd: "node-web-audio-api:worklet:process-invalid".to_string(),
-            err,
+        // error thrown in process
+        Either::B(err) => Some(WorkletAbruptCompletionResult {
+            cmd: "node-web-audio-api:worklet:process-error".to_string(),
+            err: err.into(),
         }),
     };
 

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -131,10 +131,6 @@ thread_local! {
     static HAS_THREAD_PRIO: Cell<bool> = const { Cell::new(false) };
 }
 
-struct WorkletAbruptCompletionResult {
-    cmd: String,
-    err: Error,
-}
 
 /// Check that given JS and Rust input / output layout are the same,
 /// i.e. that each input / output have the same number of channels
@@ -315,17 +311,6 @@ fn process_audio_worklet(
     }
 
     let render_quantum_size = global.get_named_property::<u32>("renderQuantumSize")? as usize;
-    // The `process` method is executed indirectly because napi-rs `apply`
-    // implementation retrieve the arguments as an array in the first argument, Then
-    // we need to unpack them first (cf. `AudioWorkletProcessor[kWorkletUnpackProcess]`)
-    let k_worklet_unpack_process = env.symbol_for("node-web-audio-api:worklet-unpack-process")?;
-
-    // The `kWorkletUnpackProcess` wrapper function coerce value returned from `process`
-    // to bool, therefore if we get anything else, i.e. `Unknown`, an error occurred.
-    let unpack_process_function = processor
-        .get_property::<JsSymbol, Function<(Array, Array, Object), Either<bool, Unknown>>>(
-            k_worklet_unpack_process,
-        )?;
 
     let k_worklet_inputs = env.symbol_for("node-web-audio-api:worklet-inputs")?;
     let mut js_inputs = processor.get_property::<JsSymbol, Array>(k_worklet_inputs)?;
@@ -381,7 +366,6 @@ fn process_audio_worklet(
     }
 
     // Copy params values into JS params buffers
-    //
     // @todo(perf) - We could rely on the fact that ParameterDescriptors
     // are ordered maps to avoid sending param names in `param_values`
     for (name, data) in param_values.iter() {
@@ -396,59 +380,40 @@ fn process_audio_worklet(
         js_params.set_named_property(name, param_values)?;
     }
 
-    let js_result = unpack_process_function.apply(processor, (js_inputs, js_outputs, js_params))?;
+    // The `process` method is executed indirectly because napi-rs `apply` implementation
+    // retrieve the arguments as an array in the first argument, Then we need to unpack
+    // them first (cf. `AudioWorkletProcessor[kWorkletUnpackProcess]`)
+    let k_worklet_unpack_process = env.symbol_for("node-web-audio-api:worklet-unpack-process")?;
 
-    let abrupt_completion = match js_result {
-        Either::A(tail_time) => {
-            // copy JS output buffers back into outputs
-            for (output_number, output) in outputs.iter().enumerate() {
-                let js_output = js_outputs.get_element::<Array>(output_number as u32)?;
+    // The `kWorkletUnpackProcess` wrapper function coerce value returned from `process`
+    // to bool, if any error occurred in process, it has been catched in `kWorkletUnpackProcess``
+    // which marked the processor has non-callable and returned false
+    let unpack_process_function = processor
+        .get_property::<JsSymbol, Function<(Array, Array, Object), bool>>(
+            k_worklet_unpack_process,
+        )?;
 
-                for (channel_number, channel) in output.iter().enumerate() {
-                    let js_channel = js_output
-                        .get::<Float32Array>(channel_number as u32)?
-                        .unwrap();
+    let tail_time = unpack_process_function.apply(processor, (js_inputs, js_outputs, js_params))?;
 
-                    let src = js_channel.as_ptr();
-                    let dst = channel.as_ptr() as *mut f32;
+    // copy JS output buffers back into outputs
+    for (output_number, output) in outputs.iter().enumerate() {
+        let js_output = js_outputs.get_element::<Array>(output_number as u32)?;
 
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(src, dst, render_quantum_size);
-                    }
-                }
+        for (channel_number, channel) in output.iter().enumerate() {
+            let js_channel = js_output
+                .get::<Float32Array>(channel_number as u32)?
+                .unwrap();
+
+            let src = js_channel.as_ptr();
+            let dst = channel.as_ptr() as *mut f32;
+
+            unsafe {
+                std::ptr::copy_nonoverlapping(src, dst, render_quantum_size);
             }
-
-            let _ = tail_time_sender.send(tail_time); // allowed to fail
-
-            None
         }
-        // error thrown in process
-        Either::B(err) => Some(WorkletAbruptCompletionResult {
-            cmd: "node-web-audio-api:worklet:process-error".to_string(),
-            err: err.into(),
-        }),
-    };
-
-    // Handle errors
-    // @todo - propagate back to rust side to remove processor from graph
-    if let Some(abrupt_completion) = abrupt_completion {
-        let WorkletAbruptCompletionResult { cmd, err } = abrupt_completion;
-
-        // Mark as non callable and dispatch `processorerror` event on main thread
-        let k_worklet_mark_non_callable =
-            env.symbol_for("node-web-audio-api:worklet-mark-non-callable-process")?;
-
-        let mark_non_callable_function = processor
-            .get_property::<JsSymbol, Function<(String, Object), ()>>(
-                k_worklet_mark_non_callable,
-            )?;
-        let js_error = env.create_error(err)?;
-        let _ = mark_non_callable_function.apply(processor, (cmd, js_error));
-
-        // Mark tail time to false in audio graph
-        // https://webaudio.github.io/web-audio-api/#active-source
-        let _ = tail_time_sender.send(false);
     }
+
+    let _ = tail_time_sender.send(tail_time); // allowed to fail
 
     Ok(())
 }

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -366,6 +366,20 @@ fn process_audio_worklet(
         }
     }
 
+    // Clear output buffers
+    // cf. wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-process-zero-outputs.https.html
+    for (output_number, output) in outputs.iter().enumerate() {
+        let js_output = js_outputs.get::<Array>(output_number as u32)?.unwrap();
+
+        for (channel_number, channel) in output.iter().enumerate() {
+            let mut js_channel = js_output
+                .get::<Float32Array>(channel_number as u32)?
+                .unwrap();
+            let js_channel: &mut [f32] = unsafe { js_channel.as_mut() };
+            js_channel.fill(0.);
+        }
+    }
+
     // Copy params values into JS params buffers
     //
     // @todo(perf) - We could rely on the fact that ParameterDescriptors

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -131,7 +131,6 @@ thread_local! {
     static HAS_THREAD_PRIO: Cell<bool> = const { Cell::new(false) };
 }
 
-
 /// Check that given JS and Rust input / output layout are the same,
 /// i.e. that each input / output have the same number of channels
 ///

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -354,15 +354,22 @@ fn process_audio_worklet(
             let js_params_cache =
                 processor.get_property::<JsSymbol, Object>(k_worklet_params_cache)?;
 
+            use std::time::Instant;
             // Check input and output channel layout, and rebuild JS object if something changed
             if !check_same_io_layout(&js_inputs, inputs) {
+                let start = Instant::now();
                 let new_js_inputs = rebuild_io_layout(env, js_inputs, inputs)?;
+                let duration = start.elapsed();
+                println!("rebuild input layout duration {:?}", duration);
                 processor.set_property(k_worklet_inputs, new_js_inputs)?;
                 js_inputs = processor.get_property::<JsSymbol, Array>(k_worklet_inputs)?;
             }
 
             if !check_same_io_layout(&js_outputs, outputs) {
+                let start = Instant::now();
                 let new_js_outputs = rebuild_io_layout(env, js_outputs, outputs)?;
+                let duration = start.elapsed();
+                println!("rebuild output layout duration {:?}", duration);
                 processor.set_property(k_worklet_outputs, new_js_outputs)?;
                 js_outputs = processor.get_property::<JsSymbol, Array>(k_worklet_outputs)?;
             }

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -141,7 +141,7 @@ struct WorkletAbruptCompletionResult {
 ///
 /// Note that we don't check the number of inputs / outputs as they are defined
 /// at construction and cannot be changed
-fn check_same_io_layout(js_io: &Array, rs_io: &'static [&'static [&'static [f32]]]) -> bool {
+fn is_same_io_layout(js_io: &Array, rs_io: &'static [&'static [&'static [f32]]]) -> bool {
     for (i, rs_channels) in rs_io.iter().enumerate() {
         let js_channels = js_io.get::<Array>(i as u32);
 
@@ -165,8 +165,7 @@ fn check_same_io_layout(js_io: &Array, rs_io: &'static [&'static [&'static [f32]
 
 /// Recreate the JS inputs or output data structures (input and output are handled separately).
 /// We must rebuild the whole structure from scratch because the resulting Arrays are frozen.
-///
-/// @todo - move this logic to JS to minimize language boundary crossing (needs benchmarking)
+// @note: mini benchmarks have been made w/ an alternative JS implementation, was way slower
 fn rebuild_io_layout<'a>(
     env: &'a Env,
     js_io: Array,
@@ -354,22 +353,15 @@ fn process_audio_worklet(
             let js_params_cache =
                 processor.get_property::<JsSymbol, Object>(k_worklet_params_cache)?;
 
-            use std::time::Instant;
             // Check input and output channel layout, and rebuild JS object if something changed
-            if !check_same_io_layout(&js_inputs, inputs) {
-                let start = Instant::now();
+            if !is_same_io_layout(&js_inputs, inputs) {
                 let new_js_inputs = rebuild_io_layout(env, js_inputs, inputs)?;
-                let duration = start.elapsed();
-                println!("rebuild input layout duration {:?}", duration);
                 processor.set_property(k_worklet_inputs, new_js_inputs)?;
                 js_inputs = processor.get_property::<JsSymbol, Array>(k_worklet_inputs)?;
             }
 
-            if !check_same_io_layout(&js_outputs, outputs) {
-                let start = Instant::now();
+            if !is_same_io_layout(&js_outputs, outputs) {
                 let new_js_outputs = rebuild_io_layout(env, js_outputs, outputs)?;
-                let duration = start.elapsed();
-                println!("rebuild output layout duration {:?}", duration);
                 processor.set_property(k_worklet_outputs, new_js_outputs)?;
                 js_outputs = processor.get_property::<JsSymbol, Array>(k_worklet_outputs)?;
             }

--- a/src/audio_worklet_node.rs
+++ b/src/audio_worklet_node.rs
@@ -371,7 +371,7 @@ fn process_audio_worklet(
     for (output_number, output) in outputs.iter().enumerate() {
         let js_output = js_outputs.get::<Array>(output_number as u32)?.unwrap();
 
-        for (channel_number, channel) in output.iter().enumerate() {
+        for (channel_number, _) in output.iter().enumerate() {
             let mut js_channel = js_output
                 .get::<Float32Array>(channel_number as u32)?
                 .unwrap();

--- a/tests/AudioWorklet.spec.js
+++ b/tests/AudioWorklet.spec.js
@@ -298,6 +298,23 @@ describe('AudioWorkletProcessor', () => {
       assert.isTrue(errored);
     });
 
+    it('should throw a clean error when process throws raw message', async () => {
+      let errored = false;
+
+      const audioContext = new AudioContext();
+      await audioContext.audioWorklet.addModule('./worklets/invalid-process.worklet.js');
+
+      const invalid = new AudioWorkletNode(audioContext, 'process-throws-raw');
+      invalid.addEventListener('processorerror', (e) => {
+        prettyPrintErr(e.error);
+        errored = true;
+      });
+
+      await delay(100);
+      await audioContext.close();
+      assert.isTrue(errored);
+    });
+
     it('OfflineAudioContext.startRendering should return when processor constructor is invalid', async () => {
       const audioContext = new OfflineAudioContext(1, 128, 48000);
       await audioContext.audioWorklet.addModule('./worklets/invalid-ctor.worklet.js');

--- a/tests/AudioWorklet.spec.js
+++ b/tests/AudioWorklet.spec.js
@@ -194,7 +194,7 @@ describe('AudioWorklet', () => {
       await audioContext.close();
     });
 
-    it(`should throw clean error if worklet is invalid`, async () => {
+    it(`should throw clean error if worklet is invalid (1)`, async () => {
       // blob worklets do not support import
       const blob = new Blob(['import stuff from "./abc"'], { type: 'application/javascript' });
       const objectUrl = URL.createObjectURL(blob);
@@ -213,7 +213,7 @@ describe('AudioWorklet', () => {
       assert.isTrue(errored);
     });
 
-    it(`should throw clean error if worklet is invalid`, async () => {
+    it(`should throw clean error if worklet is invalid (2)`, async () => {
       const audioContext = new AudioContext();
       let errored = false;
 

--- a/tests/AudioWorklet.spec.js
+++ b/tests/AudioWorklet.spec.js
@@ -264,6 +264,40 @@ describe('AudioWorkletProcessor', () => {
       assert.isTrue(errored);
     });
 
+    it('should throw a clean error when process is not callable', async () => {
+      let errored = false;
+
+      const audioContext = new AudioContext();
+      await audioContext.audioWorklet.addModule('./worklets/invalid-process.worklet.js');
+
+      const invalid = new AudioWorkletNode(audioContext, 'invalid-process');
+      invalid.addEventListener('processorerror', (e) => {
+        prettyPrintErr(e.error);
+        errored = true;
+      });
+
+      await delay(100);
+      await audioContext.close();
+      assert.isTrue(errored);
+    });
+
+    it('should throw a clean error when process throws', async () => {
+      let errored = false;
+
+      const audioContext = new AudioContext();
+      await audioContext.audioWorklet.addModule('./worklets/invalid-process.worklet.js');
+
+      const invalid = new AudioWorkletNode(audioContext, 'process-throws');
+      invalid.addEventListener('processorerror', (e) => {
+        prettyPrintErr(e.error);
+        errored = true;
+      });
+
+      await delay(100);
+      await audioContext.close();
+      assert.isTrue(errored);
+    });
+
     it('OfflineAudioContext.startRendering should return when processor constructor is invalid', async () => {
       const audioContext = new OfflineAudioContext(1, 128, 48000);
       await audioContext.audioWorklet.addModule('./worklets/invalid-ctor.worklet.js');

--- a/tests/OfflineAudioContext.spec.js
+++ b/tests/OfflineAudioContext.spec.js
@@ -36,7 +36,7 @@ describe('# OfflineAudioContext', () => {
       assert.deepEqual(aResult, bResult);
     });
 
-    it(`should throw clean error when called twice`, async () => {
+    it(`[TO BE IMPROVED] should throw clean error when called twice`, async () => {
       const offline = new OfflineAudioContext(1, 48000, 48000);
       await offline.startRendering();
 

--- a/tests/worklets/invalid-process.worklet.js
+++ b/tests/worklets/invalid-process.worklet.js
@@ -1,0 +1,15 @@
+class InvalidProcess extends AudioWorkletProcessor {
+  // attribute exists but is not callbable
+  process = null
+}
+
+registerProcessor('invalid-process', InvalidProcess);
+
+class ProcessThrows extends AudioWorkletProcessor {
+  // attribute exists but is not callbable
+  process = (inputs, outputs, params) => {
+    outputs[3][1] = 'throws';
+  }
+}
+
+registerProcessor('process-throws', ProcessThrows);

--- a/tests/worklets/invalid-process.worklet.js
+++ b/tests/worklets/invalid-process.worklet.js
@@ -13,3 +13,13 @@ class ProcessThrows extends AudioWorkletProcessor {
 }
 
 registerProcessor('process-throws', ProcessThrows);
+
+
+class ProcessThrowsRaw extends AudioWorkletProcessor {
+  // attribute exists but is not callbable
+  process = (inputs, outputs, params) => {
+    throw 'row string thrown';
+  }
+}
+
+registerProcessor('process-throws-raw', ProcessThrowsRaw);


### PR DESCRIPTION
WPT Results are now

**before**
```
- # pass: 168
- # fail: 21
- # type error issues: 0
```

**after**
```
- # pass: 173
- # fail: 15
- # type error issues: 0
```

**Remaining issues:**

- AudioParam does not behave as expected -> needs to be reviewed in upstream
- Configurable render quantum size -> to be implemented in upstream
- Issue with how `currentTime` and `currentFrame` are inited -> a bit quite tricky probably, means we should be able to request the information to the Rust audio thread somehow
- Blob can be deserialized in Node, which makes `audioworkletnode-onerror.https.html` fail
- Transfer of input / output underlying arrayBuffers is forbidden on our side (causes Segmentation Fault) -> really don't see why it is allowed anyway, probably won't fix
- One JS tick per quantum, cf. #128
- Plus one or two minor things 