### PR TITLE
Feat: expose `runDiagnostic` API under "diagnostic" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ strip = true
 jack = ["web-audio-api/cpal-jack"]
 linux = ["web-audio-api/cpal-pipewire", "web-audio-api/cpal-jack"]
 wpt = ["web-audio-api/spec-compliant-worklet-inputs"]
+diagnostics = ["web-audio-api/diagnostics"]

--- a/examples/diagnotics.js
+++ b/examples/diagnotics.js
@@ -1,0 +1,35 @@
+import { AudioContext, OscillatorNode } from '#node-web-audio-api';
+
+import { sleep } from '@ircam/sc-utils';
+
+// ------------------------------------------------------------------
+// WARNING
+//
+// the API in this example is non-standard
+// Build library with `npm run build:diagnostics` to have it work
+// ------------------------------------------------------------------
+
+const audioContext = new AudioContext();
+
+const src = new OscillatorNode(audioContext, { frequency: 220 });
+src.connect(audioContext.destination);
+src.start();
+
+const intervalId = setInterval(() => {
+  try {
+    audioContext.runDiagnostics(e => console.log(e));
+  } catch (err) {
+    console.log('');
+    console.log(err.message);
+    console.log('');
+    process.exit();
+  }
+}, 200);
+
+await sleep(6);
+
+clearInterval(intervalId);
+src.stop();
+audioContext.close();
+
+

--- a/generator/rs/lib.tmpl.rs
+++ b/generator/rs/lib.tmpl.rs
@@ -15,8 +15,6 @@ use crate::events::*;
 
 #[cfg(feature = "diagnostics")]
 mod diagnostics;
-// #[cfg(feature = "diagnostics")]
-// use crate::diagnostics::*;
 
 mod audio_destination_node;
 use crate::audio_destination_node::NapiAudioDestinationNode;

--- a/generator/rs/lib.tmpl.rs
+++ b/generator/rs/lib.tmpl.rs
@@ -13,6 +13,11 @@ use crate::offline_audio_context::NapiOfflineAudioContext;
 mod events;
 use crate::events::*;
 
+#[cfg(feature = "diagnostics")]
+mod diagnostics;
+// #[cfg(feature = "diagnostics")]
+// use crate::diagnostics::*;
+
 mod audio_destination_node;
 use crate::audio_destination_node::NapiAudioDestinationNode;
 mod audio_param;

--- a/js/AudioContext.js
+++ b/js/AudioContext.js
@@ -291,6 +291,19 @@ export class AudioContext extends BaseAudioContext {
 
     throw new Error(`AudioContext::createMediaStreamDestination() is not yet implemented, cf. https://github.com/ircam-ismm/node-web-audio-api/issues/91 for more information`);
   }
+
+  // non-standard API
+  runDiagnostics(callback) {
+    try {
+      this[kNapiObj].runDiagnostics(callback);
+    } catch (err) {
+      if (err.message === 'diagnostic feature not activated') {
+        throw new Error('Cannot execute "runDiagnostics" on AudioContext: diagnostic feature is not activated, you must build the library with `npm run build:diagnostics` to activate this method');
+      } else {
+        throw err;
+      }
+    }
+  }
 }
 
 Object.defineProperties(AudioContext, {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:jack": "npm run generate && cargo build --features jack --release && node ./.scripts/move-artifact.js --release",
     "build:linux": "npm run generate && cargo build --features linux --release && node ./.scripts/move-artifact.js --release",
     "build:debug": "npm run generate && cargo build && node ./.scripts/move-artifact.js",
+    "build:diagnostics": "npm run generate && cargo build --release --features diagnostics && node ./.scripts/move-artifact.js --release",
     "build:wpt": "npm run generate && cargo build --features wpt --release && node ./.scripts/move-artifact.js --release",
     "build:only": "cargo build --release && node ./.scripts/move-artifact.js --release",
     "examples:install": "cd examples && npm install",

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -211,6 +211,44 @@ impl NapiAudioContext {
         Ok(())
     }
 
+    // note: #[cfg(feature = "diagnostics")] somehow conflicts with #[napi]
+    // hence we declare the method in all cases and switch cfg inside the body
+    // note that `callback` is prefixed with _ to avoid warning in "normal" build
+    #[napi(catch_unwind)]
+    pub fn run_diagnostics(&self, _callback: Function<(), ()>) -> Result<()> {
+        #[cfg(feature = "diagnostics")]
+        {
+            let tsfn = _callback
+                .build_threadsafe_function()
+                .weak::<true>() // do not prevent process to exit
+                .build_callback(
+                    move |ctx: napi::threadsafe_function::ThreadsafeCallContext<
+                        web_audio_api::context::AudioContextDiagnostics,
+                    >| {
+                        let diagnostic = crate::diagnostics::NapiAudioContextDiagnostics::from(
+                            ctx.value.clone(),
+                        );
+
+                        Ok(diagnostic)
+                    },
+                )?;
+
+            self.inner.run_diagnostics(move |e| {
+                tsfn.call(
+                    e,
+                    napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
+                );
+            });
+
+            return Ok(());
+        }
+
+        #[cfg(not(feature = "diagnostics"))]
+        {
+            Err(napi::Error::from_reason("diagnostic feature not activated"))
+        }
+    }
+
     // attribute EventHandler onerror;
     // [SameObject] readonly attribute AudioPlaybackStats playbackStats;
     // AudioTimestamp getOutputTimestamp ();

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -211,8 +211,8 @@ impl NapiAudioContext {
         Ok(())
     }
 
-    // note: #[cfg(feature = "diagnostics")] somehow conflicts with #[napi]
-    // hence we declare the method in all cases and switch cfg inside the body
+    // Note: #[cfg(feature = "diagnostics")] somehow conflicts with #[napi]
+    // Hence we declare the method in all cases and switch cfg inside the body
     // note that `callback` is prefixed with _ to avoid warning in "normal" build
     #[napi(catch_unwind)]
     pub fn run_diagnostics(&self, _callback: Function<(), ()>) -> Result<()> {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,94 @@
+use napi_derive::napi;
+
+use web_audio_api::context::AudioContextDiagnostics;
+
+// Simplified diagnostics wrapper (to be completed)
+
+#[napi(object)]
+pub struct NapiAudioContextDiagnostics {
+    // Audio backend details collected on the control thread.
+    pub backend: NapiAudioBackendDiagnostics,
+    // Render thread details collected on the render thread.
+    pub render_thread: NapiAudioRenderThreadDiagnostics,
+    // Audio graph details collected on the render thread.
+    pub graph: NapiAudioGraphDiagnostics,
+}
+
+impl NapiAudioContextDiagnostics {
+    pub(crate) fn from(diagnostics: AudioContextDiagnostics) -> NapiAudioContextDiagnostics {
+        let AudioContextDiagnostics {
+            backend,
+            render_thread,
+            graph,
+            ..
+        } = diagnostics;
+
+        let backend = NapiAudioBackendDiagnostics {
+            name: backend.name,
+            sink_id: backend.sink_id,
+            output_latency: backend.output_latency,
+        };
+
+        let render_thread = NapiAudioRenderThreadDiagnostics {
+            sample_rate: render_thread.sample_rate as f64,
+            buffer_size: render_thread.buffer_size as f64,
+            frames_played: render_thread.frames_played as f64,
+            number_of_channels: render_thread.number_of_channels as f64,
+            suspended: render_thread.suspended,
+        };
+
+        let graph = NapiAudioGraphDiagnostics {
+            active: graph.active,
+            node_count: graph.node_count as f64,
+            edge_count: graph.edge_count as f64,
+        };
+
+        Self {
+            backend,
+            render_thread,
+            graph,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NapiAudioBackendDiagnostics {
+    /// Backend implementation name.
+    pub name: String,
+    /// Current audio output device id.
+    pub sink_id: String,
+    /// Current output latency in seconds, if the backend can report it.
+    pub output_latency: Option<f64>,
+}
+
+#[napi(object)]
+pub struct NapiAudioRenderThreadDiagnostics {
+    /// Render thread sample rate in Hz.
+    pub sample_rate: f64,
+    /// Backend callback buffer size in frames.
+    pub buffer_size: f64,
+    /// Number of frames played by the backend.
+    pub frames_played: f64,
+    /// Number of output channels used by the backend stream.
+    pub number_of_channels: f64,
+    /// Whether rendering is currently suspended.
+    pub suspended: bool,
+}
+
+#[napi(object)]
+pub struct NapiAudioGraphDiagnostics {
+    /// Whether the graph is loaded
+    pub active: bool,
+    /// Number of registered nodes.
+    pub node_count: f64,
+    /// Number of outgoing graph connections.
+    pub edge_count: f64,
+    // /// Node ids in the current render ordering.
+    // pub ordered: Vec<u64>,
+    // /// Node ids currently excluded from rendering because they are in an unbreakable cycle.
+    // pub in_cycle: Vec<u64>,
+    // /// Node ids marked as eligible cycle breakers.
+    // pub cycle_breakers: Vec<u64>,
+    // /// Registered audio nodes.
+    // pub nodes: Vec<AudioNodeDiagnostics>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@ use crate::events::*;
 
 #[cfg(feature = "diagnostics")]
 mod diagnostics;
-// #[cfg(feature = "diagnostics")]
-// use crate::diagnostics::*;
 
 mod audio_destination_node;
 use crate::audio_destination_node::NapiAudioDestinationNode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,11 @@ use crate::offline_audio_context::NapiOfflineAudioContext;
 mod events;
 use crate::events::*;
 
+#[cfg(feature = "diagnostics")]
+mod diagnostics;
+// #[cfg(feature = "diagnostics")]
+// use crate::diagnostics::*;
+
 mod audio_destination_node;
 use crate::audio_destination_node::NapiAudioDestinationNode;
 mod audio_param;


### PR DESCRIPTION
**Warning**: This is non-standard API

```js
audioContext.runDiagnostics(d => console.log(d));
```

Require the library to be built with the `diagnostics` feature: `npm run build:diagnostics`

Fixes #191 